### PR TITLE
Allow specifying a branch to queue on

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # CircleCI Concurrency Control Orb
+
 CircleCI Orb to limit workflow concurrency.
 
-WHy?  Some jobs (typically deployments) need to run sequentially and not parrellel, but also run to completion. So CircleCI's native `auto-cancel` is not quite the right fit.
+Why? Some jobs (typically deployments) need to run sequentially and not parallel, but also run to completion. So CircleCI's native `auto-cancel` is not quite the right fit.
 See https://github.com/eddiewebb/circleci-challenge as an example using blue/green cloud foundry deployments.
 
 [![CircleCI](https://circleci.com/gh/eddiewebb/circleci-queue/tree/master.svg?style=svg)](https://circleci.com/gh/eddiewebb/circleci-queue/tree/master)
 
 ## Basic Usage
-This adds concurreny limits by ensuring any jobs with this step will only continue once no previous builds are running.  It supports a single argument of how many minutes to wait before aborting itself and it requires a single Environment Variable `CIRCLECI_API_KEY` - which can be created in [account settings](https://circleci.com/account/api).
 
+This adds concurrency limits by ensuring any jobs with this step will only continue once no previous builds are running. It supports a single argument of how many minutes to wait before aborting itself and it requires a single Environment Variable `CIRCLECI_API_KEY` - which can be created in [account settings](https://circleci.com/account/api).
 
 ## Screenshots / Examples
-Suppose we have a workflow take takes a little while to run.  Normally the build (#18) will run immediately, with no queuing.
+
+Suppose we have a workflow take takes a little while to run. Normally the build (#18) will run immediately, with no queuing.
 ![no queuing if only active build](assets/build_noqueue.png)
 
 Someone else on the team makes another commit, since the first build (#18) is still running, it will queue build #19.
@@ -24,7 +26,7 @@ Meanwhile, build #19 is now allowed to move forward since build #18 finished.
 
 ![no queuing if only active build](assets/build_progressed.png)
 
-Oh No!  Since `1 minute` is abnormally long for things to be queued, build #20 aborts itself, letting build #19 finish uninterupted.
+Oh No! Since `1 minute` is abnormally long for things to be queued, build #20 aborts itself, letting build #19 finish uninterrupted.
 
 ![no queuing if only active build](assets/build_aborted.png)
 
@@ -38,16 +40,15 @@ version: 2.1
 jobs:
   some-job:
     docker:
-      - image: eddiewebb/circleci-queue:latest  
+      - image: eddiewebb/circleci-queue:latest
     steps:
       - queue/until_front_of_line:
-          time: 10 # max wait, in minutes (defautl 10)
-          consider-job: true #only block for this job or anyrunning builds in this project?
-          consider-branch: true #only block of running job is on same branch (drefaut true)
-          dont-quit: If max-time is exceeded, this option will allow the build to proceed.
+          time: 10                # max wait, in minutes (default 10)
+          consider-job: true      # only block for this job or any running builds in this project?
+          consider-branch: true   # only block of running job is on same branch (default true)
+          dont-quit: true         # If max-time is exceeded, this option will allow the build to proceed.
+          only-on-branch: master  # restrict queueing to a specific branch (default *)
 
       - checkout
       - ...   #your commands
- 
-
 ```

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -40,10 +40,10 @@ steps:
         QUEUE_BRUTE=[ "<<parameters.dont-quit>>" == "true" ]
         QUEUE_ONLY=<<parameters.only-on-branch>>
 
-        if [ $QUEUE_ONLY -eq "*" ] ||  [ $QUEUE_ONLY -eq $CIRCLE_BRANCH ]; then
+        if [ "$QUEUE_ONLY" = "*" ] || [ "$QUEUE_ONLY" = "${CIRCLE_BRANCH}" ]; then
           echo "${CIRCLE_BRANCH} queueable"
         else
-          echo "Queueing only happens on ${QUEUE_ONLY}, proceeding"
+          echo "Queueing only happens on ${QUEUE_ONLY}, skipping queue"
           exit 0
         fi
 

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -16,6 +16,10 @@ parameters:
     type: boolean
     default: false
     description: "Quiting is for losers. Force job through once time expires instead of failing."
+  only-on-branch:
+    type: string
+    default: "*"
+    description: "Only queue on specified branch"
 steps:
   - run:
       name: Queue Until Front of Line
@@ -27,14 +31,21 @@ steps:
         : ${CIRCLE_PROJECT_REPONAME:?"Required Env Variable not found!"}
         : ${CIRCLE_REPOSITORY_URL:?"Required Env Variable not found!"}
         : ${CIRCLE_JOB:?"Required Env Variable not found!"}
+        : ${CIRCLE_BRANCH:?"Required Env Variable not found!"}
 
 
         QUEUE_BRANCH=[ "<<parameters.consider-branch>>" == "true" ]
         QUEUE_JOB=[ "<<parameters.consider-job>>" == "true" ]
         QUEUE_TIME=<<parameters.time>>
         QUEUE_BRUTE=[ "<<parameters.dont-quit>>" == "true" ]
+        QUEUE_ONLY=<<parameters.only-on-branch>>
 
-
+        if [ $QUEUE_ONLY -eq "*" ] ||  [ $QUEUE_ONLY -eq $CIRCLE_BRANCH ]; then
+          echo "${CIRCLE_BRANCH} queueable"
+        else
+          echo "Queueing only happens on ${QUEUE_ONLY}, proceeding"
+          exit 0
+        fi
 
 
         VCS_TYPE="github"

--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -16,7 +16,11 @@ parameters:
     type: boolean
     default: false
     description: "Quiting is for losers. Force job through once time expires instead of failing."
-docker: 
+  only-on-branch:
+    type: string
+    default: "*"
+    description: "Only queue on specified branch"
+docker:
   - image: circleci/node:10 #its just really popular, and therefore fast (cached)
 steps:
   - until_front_of_line:
@@ -24,3 +28,4 @@ steps:
       consider-job: <<parameters.consider-job>>
       time: <<parameters.time>>
       dont-quit: <<parameters.dont-quit>>
+      only-on-branch: <<parameters.only-on-branch>>

--- a/test/inputs/command-filter-branch.yml
+++ b/test/inputs/command-filter-branch.yml
@@ -1,0 +1,9 @@
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/repo
+    steps:
+      - queue/until_front_of_line:
+          time: "1"
+          only-on-branch: "master"

--- a/test/test_expansion.bats
+++ b/test/test_expansion.bats
@@ -60,6 +60,7 @@ function setup {
   export CIRCLE_PROJECT_USERNAME="madethisup"
   export CIRCLE_PROJECT_REPONAME="madethisup"
   export CIRCLE_REPOSITORY_URL="madethisup"
+  export CIRCLE_BRANCH="madethisup"
   run bash ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
 
@@ -86,6 +87,7 @@ function setup {
   export CIRCLE_PROJECT_USERNAME="madethisup"
   export CIRCLE_PROJECT_REPONAME="madethisup"
   export CIRCLE_REPOSITORY_URL="madethisup"
+  export CIRCLE_BRANCH="madethisup"
   run bash ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
 
@@ -111,6 +113,7 @@ function setup {
   export CIRCLE_PROJECT_USERNAME="madethisup"
   export CIRCLE_PROJECT_REPONAME="madethisup"
   export CIRCLE_REPOSITORY_URL="madethisup"
+  export CIRCLE_BRANCH="madethisup"
   run bash ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
 
@@ -137,6 +140,7 @@ function setup {
   export CIRCLE_PROJECT_USERNAME="madethisup"
   export CIRCLE_PROJECT_REPONAME="madethisup"
   export CIRCLE_REPOSITORY_URL="madethisup"
+  export CIRCLE_BRANCH="madethisup"
   run bash ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
 
@@ -177,6 +181,32 @@ function setup {
 }
 
 
+@test "Command: script will skip queueing on branches that don't match filter" {
+  # given
+  process_config_with test/inputs/command-filter-branch.yml
+  export TESTING_MOCK_RESPONSE=test/api/nopreviousjobs.json #Response shouldn't matter as we're ending early
+
+  # when
+  assert_jq_match '.jobs | length' 1 #only 1 job
+  assert_jq_match '.jobs["build"].steps | length' 1 #only 1 steps
+
+  jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
+
+  export CIRCLECI_API_KEY="madethisup"
+  export CIRCLE_BUILD_NUM="2"
+  export CIRCLE_BRANCH="dev"
+  export CIRCLE_JOB="singlejob"
+  export CIRCLE_PROJECT_USERNAME="madethisup"
+  export CIRCLE_PROJECT_REPONAME="madethisup"
+  export CIRCLE_REPOSITORY_URL="madethisup"
+  run bash ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
+
+
+  assert_contains_text "Queueing only happens on master, skipping queue"
+  assert_text_not_found "Max Queue Time: 1 minutes"
+  [[ "$status" == "0" ]]
+
+}
 
 @test "Command: script will consider branch default" {
   # given
@@ -199,6 +229,7 @@ function setup {
   run bash ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
 
+  assert_contains_text "${CIRCLE_BRANCH} queueable"
   assert_contains_text "Max Queue Time: 1 minutes"
   assert_contains_text "Only blocking execution if running previous jobs on branch: ${CIRCLE_BRANCH}"
   assert_contains_text "Front of the line, WooHoo!, Build continuing"
@@ -228,6 +259,7 @@ function setup {
   export CIRCLE_PROJECT_USERNAME="madethisup"
   export CIRCLE_PROJECT_REPONAME="madethisup"
   export CIRCLE_REPOSITORY_URL="madethisup"
+  export CIRCLE_BRANCH="madethisup"
   run bash ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
 


### PR DESCRIPTION
I was trying to use this in https://github.com/artsy/reaction/pull/1481 and I ran into an issue where I only needed it to run on master, but I didn't really have a good way of achieving that. If you look back in the commits in that PR you'll see where I tried to make all the steps require before our `deploy` job depend on a `pre-deploy` job that was filtered to only run on master... turns out, that just makes none of them run. 