### PR TITLE
Remove evaluations of variables in favor of raw parameter use

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -34,16 +34,11 @@ steps:
         : ${CIRCLE_BRANCH:?"Required Env Variable not found!"}
 
 
-        QUEUE_BRANCH=[ "<<parameters.consider-branch>>" == "true" ]
-        QUEUE_JOB=[ "<<parameters.consider-job>>" == "true" ]
-        QUEUE_TIME=<<parameters.time>>
-        QUEUE_BRUTE=[ "<<parameters.dont-quit>>" == "true" ]
-        QUEUE_ONLY=<<parameters.only-on-branch>>
 
-        if [ "$QUEUE_ONLY" = "*" ] || [ "$QUEUE_ONLY" = "${CIRCLE_BRANCH}" ]; then
+        if [ "<<parameters.only-on-branch>>" = "*" ] || [ "<<parameters.only-on-branch>>" = "${CIRCLE_BRANCH}" ]; then
           echo "${CIRCLE_BRANCH} queueable"
         else
-          echo "Queueing only happens on ${QUEUE_ONLY}, skipping queue"
+          echo "Queueing only happens on <<parameters.only-on-branch>> branch, skipping queue"
           exit 0
         fi
 
@@ -96,7 +91,7 @@ steps:
 
 
 
-        max_time=${QUEUE_TIME}
+        max_time=<<parameters.time>>
         echo "This build will block until all previous builds complete."
         echo "Max Queue Time: ${max_time} minutes."
 

--- a/test/test_expansion.bats
+++ b/test/test_expansion.bats
@@ -38,7 +38,7 @@ function setup {
 
   run jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG
 
-  assert_contains_text "QUEUE_TIME=1"
+  assert_contains_text "max_time=1"
 
 }
 
@@ -202,7 +202,7 @@ function setup {
   run bash ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
 
-  assert_contains_text "Queueing only happens on master, skipping queue"
+  assert_contains_text "Queueing only happens on master branch, skipping queue"
   assert_text_not_found "Max Queue Time: 1 minutes"
   [[ "$status" == "0" ]]
 


### PR DESCRIPTION
This should fix the issue we're seeing @zephraph 

I've killed all the attempts to set a variable based on result of bash test blocks, instead using the parameters directly within the logic as needed.