### PR TITLE
Fix environment variable issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ jobs:
       - checkout
       - ...   #your commands
 ```
+
+## Note
+
+Queueing is not supported on forked repos. If a queue from a fork happens the queue will immediately exit and the next step of the job will begin.

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -24,8 +24,8 @@ steps:
   - run:
       name: Queue Until Front of Line
       command: |
+
         # just confirm our required variables are present
-        : ${CIRCLECI_API_KEY:?"Required Env Variable not found!"}
         : ${CIRCLE_BUILD_NUM:?"Required Env Variable not found!"}
         : ${CIRCLE_PROJECT_USERNAME:?"Required Env Variable not found!"}
         : ${CIRCLE_PROJECT_REPONAME:?"Required Env Variable not found!"}
@@ -33,6 +33,10 @@ steps:
         : ${CIRCLE_JOB:?"Required Env Variable not found!"}
         : ${CIRCLE_BRANCH:?"Required Env Variable not found!"}
 
+        # Only needed for private projects
+        if [ -z "$CIRCLECI_API_KEY" ]; then
+          echo "CIRCLECI_API_KEY not set. Private projects will be inaccessable."
+        fi
 
         QUEUE_BRANCH=[ "<<parameters.consider-branch>>" == "true" ]
         QUEUE_JOB=[ "<<parameters.consider-job>>" == "true" ]

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -20,10 +20,6 @@ parameters:
     type: string
     default: "*"
     description: "Only queue on specified branch"
-  ignore-forks:
-    type: boolean
-    default: true
-    description: "Whether queuing should happen on a fork. Forks will only queue on public repos."
   vcs-type:
     type: string
     default: "github"
@@ -34,8 +30,9 @@ steps:
       command: |
 
 
-        if [ ! -z "$CIRCLE_PR_REPONAME" ] && [ "<<parameters.ignore-forks>>" == "true" ]; then
-          echo "Skipping queue for forked build"
+        if [ ! -z "$CIRCLE_PR_REPONAME" ]; then
+          echo "Queueing on forks is not supported. Skipping queue..."
+          # It's important that we not fail here because it could cause issues on the main repo's branch
           exit 0
         fi
 

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -68,8 +68,14 @@ steps:
 
 
         load_oldest_running_build_num(){
-          curl -s $jobs_api_url_template > /tmp/jobstatus.json
-          if [ -f $TESTING_MOCK_RESPONSE ];then cat $TESTING_MOCK_RESPONSE > /tmp/jobstatus.json; fi
+          if [ -f $TESTING_MOCK_RESPONSE ];then 
+            echo "Using test mock response"
+            cat $TESTING_MOCK_RESPONSE > /tmp/jobstatus.json 
+          else
+            echo "Attempting to access CircleCI api. If the build process fails after this step, ensure your CIRCLECI_API_KEY is set."
+            curl -f -s $jobs_api_url_template > /tmp/jobstatus.json
+            echo "API access successful"
+          fi
 
           #negative index grabs last (oldest) job in returned results.
           if [ "<<parameters.consider-job>>" != "true" ];then

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -20,10 +20,20 @@ parameters:
     type: string
     default: "*"
     description: "Only queue on specified branch"
+  ignore-forks:
+    type: boolean
+    default: true
+    description: "Whether queuing should happen on a fork. Forks will only queue on public repos."
 steps:
   - run:
       name: Queue Until Front of Line
       command: |
+
+
+        if [ ! -z "$CIRCLE_PR_REPONAME" ] && [ "<<parameters.ignore-forks>>" == "true" ]; then
+          echo "Skipping queue for forked build"
+          exit 0
+        fi
 
         # just confirm our required variables are present
         : ${CIRCLE_BUILD_NUM:?"Required Env Variable not found!"}

--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -20,10 +20,6 @@ parameters:
     type: string
     default: "*"
     description: "Only queue on specified branch"
-  ignore-forks:
-    type: boolean
-    default: true
-    description: "Whether queuing should happen on a fork. Forks will only queue on public repos."
 docker:
   - image: circleci/node:10 #its just really popular, and therefore fast (cached)
 steps:

--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -20,6 +20,10 @@ parameters:
     type: string
     default: "*"
     description: "Only queue on specified branch"
+  ignore-forks:
+    type: boolean
+    default: true
+    description: "Whether queuing should happen on a fork. Forks will only queue on public repos."
 docker:
   - image: circleci/node:10 #its just really popular, and therefore fast (cached)
 steps:

--- a/test/test_expansion.bats
+++ b/test/test_expansion.bats
@@ -286,34 +286,7 @@ function setup {
   export CIRCLE_PR_REPONAME="fork"
 
   run bash ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
-  assert_contains_text "Skipping queue for forked build"
+  assert_contains_text "Queueing on forks is not supported. Skipping queue..."
 
 }
-
-
-@test "Command: script will try to queue on forks when ignore-forks not set" {
-  # given
-  process_config_with test/inputs/command-defaults.yml
-
-  # when
-  assert_jq_match '.jobs | length' 1 #only 1 job
-  assert_jq_match '.jobs["build"].steps | length' 1 #only 1 steps
-
-  jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
-
-  export CIRCLECI_API_KEY="madethisup"
-  export CIRCLE_BUILD_NUM="2"
-  export CIRCLE_JOB="singlejob"
-  export CIRCLE_PROJECT_USERNAME="madethisup"
-  export CIRCLE_PROJECT_REPONAME="madethisup"
-  export CIRCLE_REPOSITORY_URL="madethisup"
-  export CIRCLE_BRANCH="madethisup"
-
-  run bash ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
-  assert_text_not_found "Skipping queue for forked build"
-  
-}
-
-
-
 

--- a/test/test_expansion.bats
+++ b/test/test_expansion.bats
@@ -239,9 +239,6 @@ function setup {
 
 
 
-
-
-
 @test "Command: script will queue on different job when consider-job is false" {
   # given
   process_config_with test/inputs/command-non-default.yml
@@ -269,8 +266,53 @@ function setup {
 }
 
 
+@test "Command: script will skip queueing on forks when ignore-forks set" {
+  # given
+  process_config_with test/inputs/command-defaults.yml
+
+  # when
+  assert_jq_match '.jobs | length' 1 #only 1 job
+  assert_jq_match '.jobs["build"].steps | length' 1 #only 1 steps
+
+  jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
+
+  export CIRCLECI_API_KEY="madethisup"
+  export CIRCLE_BUILD_NUM="2"
+  export CIRCLE_JOB="singlejob"
+  export CIRCLE_PROJECT_USERNAME="madethisup"
+  export CIRCLE_PROJECT_REPONAME="madethisup"
+  export CIRCLE_REPOSITORY_URL="madethisup"
+  export CIRCLE_BRANCH="madethisup"
+  export CIRCLE_PR_REPONAME="fork"
+
+  run bash ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
+  assert_contains_text "Skipping queue for forked build"
+
+}
 
 
+@test "Command: script will try to queue on forks when ignore-forks not set" {
+  # given
+  process_config_with test/inputs/command-defaults.yml
+
+  # when
+  assert_jq_match '.jobs | length' 1 #only 1 job
+  assert_jq_match '.jobs["build"].steps | length' 1 #only 1 steps
+
+  jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
+
+  export CIRCLECI_API_KEY="madethisup"
+  export CIRCLE_BUILD_NUM="2"
+  export CIRCLE_JOB="singlejob"
+  export CIRCLE_PROJECT_USERNAME="madethisup"
+  export CIRCLE_PROJECT_REPONAME="madethisup"
+  export CIRCLE_REPOSITORY_URL="madethisup"
+  export CIRCLE_BRANCH="madethisup"
+
+  run bash ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
+  assert_text_not_found "Skipping queue for forked build"
+  
+}
 
 
 

--- a/test/test_expansion.bats
+++ b/test/test_expansion.bats
@@ -266,7 +266,7 @@ function setup {
 }
 
 
-@test "Command: script will skip queueing on forks when ignore-forks set" {
+@test "Command: script will skip queueing on forks" {
   # given
   process_config_with test/inputs/command-defaults.yml
 


### PR DESCRIPTION
Ran into a few issues as detailed here: https://github.com/artsy/reaction/pull/1517.

This fix will do two things: 

1. Make `CIRCLECI_API_KEY` not required (but warn if it isn't present)
2. Update the oldest job logic to not fail if a job isn't detected