### PR TITLE
Remove accidental load_current_workflow_values

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -134,7 +134,6 @@ steps:
         wait_time=0
         loop_time=11
         max_time_seconds=$((max_time * 60))
-        load_current_workflow_values
        
         #
         # Queue Loop


### PR DESCRIPTION
Current this job fails to run, as load_current_workflow_values tries to load /tmp/jobstatus.json before it has been curled.

Removing this won't cause any issues, as the first line of the while true loop will update job status and then re-call load_current_workflow_values

EDIT: Tests are failing because I lack a token