### PR TITLE
Update job to use small resource class [semver:minor]

### DIFF
--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -32,6 +32,7 @@ parameters:
 
 docker:
   - image: circleci/node:10 #its just really popular, and therefore fast (cached)
+resource_class: small
 steps:
   - until_front_of_line:
       consider-branch: <<parameters.consider-branch>>


### PR DESCRIPTION
Let's be frugal

### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Reduces needless credit consumption

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Set resource_class to 'small' on the `block_workflow` job