### PR TITLE
validate job should ignore master, run everywhere else [semver:skip]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,8 @@ workflows:
       - validate:
           filters:
             branches:
-              only: 
-                - staging
-                - trying
+              ignore: 
+                - master
       - test:
           requires: 
             - validate


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x README has been updated, if necessary

### Motivation, issues

The validate job was only running for bors merge/try, missing important feedback to users.  Setting to still ignore master branch, but run elsewhere.

### Description

adds filter > ignore > `master` to the linting/validate job of workflow.
