### PR TITLE
Docs: Mention "time" being set in minutes [semver:patch]

### DIFF
--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -11,7 +11,7 @@ parameters:
   time:
     type: string
     default: "10"
-    description: "How long to wait before giving up."
+    description: "How many minutes to wait before giving up."
   dont-quit:
     type: boolean
     default: false


### PR DESCRIPTION
### Motivation, issues

Some of the code mentions the `time` parameter being in minutes, but not all.

### Description

Mention "minutes" in the description of the "time" parameter.

