### PR TITLE
[semver:patch] docs: Mention minutes in parameter.time in until_front_of_line Command

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -11,7 +11,7 @@ parameters:
   time:
     type: string
     default: "10"
-    description: "How long to wait before giving up."
+    description: "How many minutes to wait before giving up."
   dont-quit:
     type: boolean
     default: false


### PR DESCRIPTION
This PR does what #54 did, but for the other Command.

### Motivation, issues

Completeness of documentation.

### Description

Use same wording as #54 to make it easy to grasp the parameter.

