### PR TITLE
Parameterize CircleCI API Key [semver:minor]

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -28,6 +28,10 @@ parameters:
     type: string
     default: "1"
     description: "Due to scarce API, we need to requery the recent jobs list to ensure we're not just in a pending state for previous jobs.  This number indicates the threhold for API returning no previous pending jobs. Default is a single confirmation."
+  circleci-api-key:
+    type: env_var_name
+    default: CIRCLECI_API_KEY
+    description: "In case you use a different Environment Variable Name than CIRCLECI_API_KEY, supply it here."
 steps:
   - run:
       name: Queue Until Front of Line
@@ -41,8 +45,8 @@ steps:
           : ${CIRCLE_REPOSITORY_URL:?"Required Env Variable not found!"}
           : ${CIRCLE_JOB:?"Required Env Variable not found!"}
           # Only needed for private projects
-          if [ -z "$CIRCLECI_API_KEY" ]; then
-            echo "CIRCLECI_API_KEY not set. Private projects will be inaccessible."
+          if [ -z "${<< parameters.circleci-api-key >>}" ]; then
+            echo "<< parameters.circleci-api-key >> not set. Private projects will be inaccessible."
           fi
           VCS_TYPE="<<parameters.vcs-type>>"
         }
@@ -54,18 +58,18 @@ steps:
         fetch_filtered_active_builds(){
           if [ "<<parameters.consider-branch>>" != "true" ];then
             echo "Orb parameter 'consider-branch' is false, will block previous builds on any branch."
-            jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?circle-token=${CIRCLECI_API_KEY}&filter=running"
+            jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?circle-token=${<< parameters.circleci-api-key >>}&filter=running"
           else
             echo "Only blocking execution if running previous jobs on branch: ${CIRCLE_BRANCH}"
             : ${CIRCLE_BRANCH:?"Required Env Variable not found!"}
-            jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/tree/${CIRCLE_BRANCH}?circle-token=${CIRCLECI_API_KEY}&filter=running"
+            jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/tree/${CIRCLE_BRANCH}?circle-token=${<< parameters.circleci-api-key >>}&filter=running"
           fi
 
           if [ ! -z $TESTING_MOCK_RESPONSE ] && [ -f $TESTING_MOCK_RESPONSE ];then
             echo "Using test mock response"
             cat $TESTING_MOCK_RESPONSE > /tmp/jobstatus.json
           else
-            echo "Attempting to access CircleCI api. If the build process fails after this step, ensure your CIRCLECI_API_KEY is set."
+            echo "Attempting to access CircleCI api. If the build process fails after this step, ensure your << parameters.circleci-api-key >> is set."
             curl -f -s $jobs_api_url_template > /tmp/jobstatus.json
             echo "API access successful"
           fi
@@ -81,7 +85,7 @@ steps:
               echo "Using test mock workflow response"
               cat $TESTING_MOCK_WORKFLOW_RESPONSES/${workflow}.json > ${workflow_file}
             else
-              curl -f -s "https://circleci.com/api/v2/workflow/${workflow}?circle-token=${CIRCLECI_API_KEY}" > ${workflow_file}
+              curl -f -s "https://circleci.com/api/v2/workflow/${workflow}?circle-token=${<< parameters.circleci-api-key >>}" > ${workflow_file}
             fi
             created_at=`jq -r '.created_at' ${workflow_file}`
             echo "Workflow was created at: ${created_at}"
@@ -130,7 +134,7 @@ steps:
 
         cancel_current_build(){
           echo "Cancelleing build ${CIRCLE_BUILD_NUM}"
-          cancel_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/cancel?circle-token=${CIRCLECI_API_KEY}"
+          cancel_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/cancel?circle-token=${<< parameters.circleci-api-key >>}"
           curl -s -X POST $cancel_api_url_template > /dev/null
         }
 
@@ -161,7 +165,7 @@ steps:
         wait_time=0
         loop_time=11
         max_time_seconds=$((max_time * 60))
-       
+
         #
         # Queue Loop
         #

--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -28,6 +28,10 @@ parameters:
     type: string
     default: "1"
     description: "Due to scarce API, we need to requery the recent jobs list to ensure we're not just in a pending state for previous jobs.  This number indicates the threhold for API returning no previous pending jobs. Default is a single confirmation."
+  circleci-api-key:
+    type: env_var_name
+    default: CIRCLECI_API_KEY
+    description: "In case you use a different Environment Variable Name than CIRCLECI_API_KEY, supply it here."
 
 docker:
   - image: cimg/base:stable
@@ -41,3 +45,4 @@ steps:
       only-on-branch: <<parameters.only-on-branch>>
       vcs-type: <<parameters.vcs-type>>
       confidence: <<parameters.confidence>>
+      circleci-api-key: <<parameters.circleci-api-key>>


### PR DESCRIPTION
Sometimes, teams don't use CIRCLECI_API_KEY as the environment variable
name that holds their api keys, so allow them to provide it but don't
change the default behavior for existing users. Adds #56

### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

#56 Covers the motivation, our team uses a different variable for storing our circleci api key, so we want to be able to supply that to an orb.

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

Adds a parameter for specifying the name of the environment variable which stores your API key.

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
