### PR TITLE
[semver:patch] More confidence and empty timing check to prevent starting early

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -174,7 +174,7 @@ steps:
           update_comparables
           echo "This Workflow Timestamp: $my_commit_time"
           echo "Oldest Workflow Timestamp: $oldest_commit_time"
-          if [[ "$oldest_commit_time" > "$my_commit_time" ]] || [[ "$oldest_commit_time" = "$my_commit_time" ]] ; then
+          if [[ ! -z "$my_commit_time" ]] && [[ "$oldest_commit_time" > "$my_commit_time" || "$oldest_commit_time" = "$my_commit_time" ]] ; then
             # API returns Y-M-D HH:MM (with 24 hour clock) so alphabetical string compare is accurate to timestamp compare as well
             # recent-jobs API does not include pending, so it is posisble we queried in between a workfow transition, and we;re NOT really front of line.
             if [ $confidence -lt <<parameters.confidence>> ];then
@@ -187,6 +187,8 @@ steps:
               break
             fi
           else
+            # If we fail, reset confidence
+            confidence=0
             echo "This build (${CIRCLE_BUILD_NUM}) is queued, waiting for build number (${oldest_running_build_num}) to complete."
             echo "Total Queue time: ${wait_time} seconds."
           fi


### PR DESCRIPTION
### Checklist

- [X] **N/A** All new jobs, commands, executors, parameters have descriptions
- [X] **N/A** Examples have been added for any significant new features
- [X] **N/A** README has been updated, if necessary

### Motivation, issues

Thanks for making this orb, it's helped us greatly,
We have seen some flakiness with multiple jobs getting through our blocking stage due to flakiness in the API.
As I understand it the confidence level is designed to resolve this however even with this we have seen issues that come from a combination of the flaky API results and some missed edge cases in the orb (I think).

#### When this orbs running job doesn't appear in the API call for running jobs.
In this case `my_commit_time` is set to an empty string since it does not find it's own job in the json returned of all running jobs.
Unfortunately because the check is that we pass if our job has a smaller commit time than all other jobs, and an empty string is smaller than some string, this results in passing the block.

My fix here is simply to always consider not knowing our own start time as a failure to pass the block.

#### The confidence does not reset
Because of the flakiness of the API we often get a few success mixed into more consistent failures to pass the block. Since the confidence level doesn't reset, overtime we can reach a point of passing the confidence level and proceeding past the block, even though success results come sporadically.

My fix here is to reset the confidence back to 0 whenever we see a failure, this ensures that you need to see `confidence` number of successes in a row rather than just across the whole time blocking in order to pass.

### Description

Do not increase confidence when the circleci API fails to report our own running job.
Reset confidence to zero whenever an earlier running job is found.
