### PR TITLE
Spelling fix in description of "dont-quit" [semver:patch]

### DIFF
--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -15,7 +15,7 @@ parameters:
   dont-quit:
     type: boolean
     default: false
-    description: "Quiting is for losers. Force job through once time expires instead of failing."
+    description: "Quitting is for losers. Force job through once time expires instead of failing."
   only-on-branch:
     type: string
     default: "*"


### PR DESCRIPTION
Quitting is for losers but spelling is for winners 😉 

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Small spelling fix.

### Description

"quiting" => "quitting"

Thanks for the helpful code!