### PR TITLE
fix tag-pattern conditions [semver:patch]

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -63,7 +63,7 @@ steps:
           if [ "<<parameters.consider-branch>>" != "true" ];then
             echo "Orb parameter 'consider-branch' is false, will block previous builds on any branch."
             jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?circle-token=${<< parameters.circleci-api-key >>}&filter=running"
-          elif [ -n "${CIRCLE_TAG:x}" && "<<parameters.tag-pattern>>" != "" ]; then
+          elif [ -n "${CIRCLE_TAG:x}" ] && [ "<<parameters.tag-pattern>>" != "" ]; then
             echo "CIRCLE_TAG and orb parameter tag-pattern is set, fetch active builds"
             jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?circle-token=${<< parameters.circleci-api-key >>}&filter=running"
           else
@@ -77,7 +77,7 @@ steps:
             cat $TESTING_MOCK_RESPONSE > /tmp/jobstatus.json
           else
             echo "Attempting to access CircleCI api. If the build process fails after this step, ensure your << parameters.circleci-api-key >> is set."
-            if [ -n "${CIRCLE_TAG:x}" && "<<parameters.tag-pattern>>" != "" ]; then
+            if [ -n "${CIRCLE_TAG:x}" ] && [ "<<parameters.tag-pattern>>" != "" ]; then
               curl -f -s $jobs_api_url_template | jq '[ .[] | select(.vcs_tag | . != null) | select(.vcs_tag | test("<<parameters.tag-pattern>>") ) ]' > /tmp/jobstatus.json
             else
               curl -f -s $jobs_api_url_template > /tmp/jobstatus.json


### PR DESCRIPTION
### Checklist

- [ n/a ] All new jobs, commands, executors, parameters have descriptions
- [ n/a ] Examples have been added for any significant new features
- [ n/a ] README has been updated, if necessary

### Motivation, issues
see #67 

the tag-pattern conditions are missing brackets that are causing them to error

### Description

the conditions were
```
[ -n "${CIRCLE_TAG:x}" && "<<parameters.tag-pattern>>" != "" ]
```

resulting in error while running
```
environment: line 23: [: missing `]'
```

added brackets, now they are
```
[ -n "${CIRCLE_TAG:x}" ] && [ "<<parameters.tag-pattern>>" != "" ]
```