### PR TITLE
[semver:patch] Fix Issue 70 - missing job_name causes empty timestamps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ commands:
       - run:
           name: Install YQ
           command: |
-            curl -L https://github.com/mikefarah/yq/releases/download/2.1.1/yq_linux_amd64 -o yq
+            curl -L https://github.com/mikefarah/yq/releases/download/v4.14.1/yq_linux_amd64 -o yq
             chmod a+x yq
             mv yq /usr/local/bin/            
   install-circleci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ workflows:
               ignore: 
                 - master
       - test:
+          context: [orbs]
           requires: 
             - validate
           filters:
@@ -24,6 +25,7 @@ workflows:
                 - staging
                 - trying
       - publish:
+          context: [orbs]
           requires:
             - test
           filters:

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -96,7 +96,7 @@ steps:
               echo "Using test mock workflow response"
               cat $TESTING_MOCK_WORKFLOW_RESPONSES/${workflow}.json > ${workflow_file}
             else
-              curl -f -s "https://circleci.com/api/v2/workflow/${workflow}?circle-token=${<< parameters.circleci-api-key >>}" > ${workflow_file}
+              fetch "https://circleci.com/api/v2/workflow/${workflow}" "${workflow_file}"
             fi
             created_at=`jq -r '.created_at' ${workflow_file}`
             echo "Workflow was created at: ${created_at}"

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -136,8 +136,12 @@ steps:
           else
             echo "Orb parameter block-workflow is false."
             echo "Only blocking execution if running previous jobs matching this job: ${CIRCLE_JOB}"
-            oldest_running_build_num=`jq ". | map(select(.build_parameters.CIRCLE_JOB==\"${CIRCLE_JOB}\")) | sort_by(.workflows.created_at)|  .[0].build_num" /tmp/augmented_jobstatus.json`
-            oldest_commit_time=`jq ". | map(select(.build_parameters.CIRCLE_JOB==\"${CIRCLE_JOB}\")) | sort_by(.workflows.created_at)|  .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
+            oldest_running_build_num=`jq ". | map(select(.workflows.job_name==\"${CIRCLE_JOB}\")) | sort_by(.workflows.created_at)|  .[0].build_num" /tmp/augmented_jobstatus.json`
+            oldest_commit_time=`jq ". | map(select(.workflows.job_name==\"${CIRCLE_JOB}\")) | sort_by(.workflows.created_at)|  .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
+          fi
+          if [ -z "$oldest_commit_time" ]; then
+            echo "API Error - unable to load previous job timings. Report to developer."
+            exit 1
           fi
           echo "Oldest job: $oldest_running_build_num"
           if [ -z $oldest_commit_time ];then

--- a/test/api/jobs/nopreviousjobs.json
+++ b/test/api/jobs/nopreviousjobs.json
@@ -6,7 +6,6 @@
   "committer_date": "2019-01-17T11:17:24-05:00",
   "branch" : "master",
   "build_parameters":{
-    "CIRCLE_JOB":"singlejob"
   },
   "workflows" : {
     "job_name" : "singlejob",

--- a/test/api/jobs/onepreviousjob-differentname.json
+++ b/test/api/jobs/onepreviousjob-differentname.json
@@ -6,7 +6,6 @@
   "committer_date": "2019-01-17T11:17:24-05:00",
   "branch" : "master",
   "build_parameters":{
-    "CIRCLE_JOB":"singlejob"
   },
   "workflows" : {
     "job_name" : "singlejob",
@@ -26,7 +25,6 @@
   "committer_date": "2019-01-17T10:17:24-05:00",
   "branch" : "master",
   "build_parameters":{
-    "CIRCLE_JOB":"adifferentjob"
   },
   "workflows" : {
     "job_name" : "adifferentjob",

--- a/test/api/jobs/onepreviousjobsamename.json
+++ b/test/api/jobs/onepreviousjobsamename.json
@@ -6,7 +6,6 @@
   "committer_date": "2019-01-17T11:17:24-05:00",
   "branch" : "master",
   "build_parameters":{
-    "CIRCLE_JOB":"singlejob"
   },
   "workflows" : {
     "job_name" : "singlejob",
@@ -26,7 +25,6 @@
   "committer_date": "2019-01-17T10:17:24-05:00",
   "branch" : "master",
   "build_parameters":{
-    "CIRCLE_JOB":"singlejob"
   },
   "workflows" : {
     "job_name" : "singlejob",

--- a/test/bats_helper.bash
+++ b/test/bats_helper.bash
@@ -4,7 +4,7 @@
 function process_config_with {
 	append_project_configuration $1 > $INPUT_PROJECT_CONFIG
  	circleci config process $INPUT_PROJECT_CONFIG > ${PROCESSED_PROJECT_CONFIG}
- 	yq read -j ${PROCESSED_PROJECT_CONFIG} > ${JSON_PROJECT_CONFIG}
+ 	yq eval -o=j ${PROCESSED_PROJECT_CONFIG} > ${JSON_PROJECT_CONFIG}
 
  	#assertions use output, tests can override outptu to test additional commands beyond parsing.
  	output=`cat  ${PROCESSED_PROJECT_CONFIG}`


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary
- [x] Test data updated to new API shape

### Motivation, issues

Change in API payload caused Issue #70 

This uses alternate object field to match job names, and includes check statement to fail build if unable to find match.

### Description

- use `workflows.job_name` instead of `parameters.CIRCLE_JOB`
- rev bats to 4.x
- update test data in `test/api/` to match current response shape
- added `if null` check for the previous commit time.