### PR TITLE
support `tag-pattern` wrapped with slashes [semver:patch]

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -40,6 +40,12 @@ steps:
   - run:
       name: Queue Until Front of Line
       command: |
+        tag_pattern="<<parameters.tag-pattern>>"
+
+        # If a pattern is wrapped with slashes, remove them.
+        if [[ "$tag_pattern" == /*/ ]]; then
+          tag_pattern=${tag_pattern:1:-1}
+        fi
 
         fetch(){
           echo "DEBUG: Making API Call to ${1}"
@@ -77,7 +83,7 @@ steps:
           if [ "<<parameters.consider-branch>>" != "true" ];then
             echo "Orb parameter 'consider-branch' is false, will block previous builds on any branch." 
             jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?filter=running"
-          elif [ -n "${CIRCLE_TAG:x}" ] && [ "<<parameters.tag-pattern>>" != "" ]; then
+          elif [ -n "${CIRCLE_TAG:x}" ] && [ "$tag_pattern" != "" ]; then
             # I'm not sure why this is here, seems identical to above?
             echo "CIRCLE_TAG and orb parameter tag-pattern is set, fetch active builds"
             jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?filter=running"
@@ -93,8 +99,8 @@ steps:
           else
             echo "Attempting to access CircleCI api. If the build process fails after this step, ensure your << parameters.circleci-api-key >>  is set."
             fetch "$jobs_api_url_template" "/tmp/jobstatus.json"
-            if [ -n "${CIRCLE_TAG:x}" ] && [ "<<parameters.tag-pattern>>" != "" ]; then
-              jq '[ .[] | select(.vcs_tag | . != null) | select(.vcs_tag | test("<<parameters.tag-pattern>>") ) ]' /tmp/jobstatus.json > /tmp/jobstatus_tag.json
+            if [ -n "${CIRCLE_TAG:x}" ] && [ "$tag_pattern" != "" ]; then
+              jq "[ .[] | select(.vcs_tag | . != null) | select(.vcs_tag | test(\"$tag_pattern\") ) ]" /tmp/jobstatus.json > /tmp/jobstatus_tag.json
               mv /tmp/jobstatus_tag.json /tmp/jobstatus.json
             fi
             echo "API access successful"

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -100,7 +100,7 @@ steps:
             echo "Attempting to access CircleCI api. If the build process fails after this step, ensure your << parameters.circleci-api-key >>  is set."
             fetch "$jobs_api_url_template" "/tmp/jobstatus.json"
             if [ -n "${CIRCLE_TAG:x}" ] && [ "$tag_pattern" != "" ]; then
-              jq "[ .[] | select(.vcs_tag | . != null) | select(.vcs_tag | test(\"$tag_pattern\") ) ]" /tmp/jobstatus.json > /tmp/jobstatus_tag.json
+              jq "[ .[] | select((.build_num | . == \"${CIRCLE_BUILD_NUM}\") or (.vcs_tag | (. != null and test(\"${tag_pattern}\"))) ) ]" /tmp/jobstatus.json >/tmp/jobstatus_tag.json
               mv /tmp/jobstatus_tag.json /tmp/jobstatus.json
             fi
             echo "API access successful"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

**Issue**
Patterns passed to CircleCI's own tag/branch filters (e.g. [`filters.tags.only`](https://circleci.com/docs/2.0/configuration-reference/#tags)) are required to be wrapped with `/` to indicate that they are patterns, like `/^release-.*/`. However, if you pass the same pattern as `tag-pattern` to `until_front_of_line` it gets stuck in an infinite queue because it passes the slashes as part of the pattern.

**Motivation**
- Stripping wrapping slashes allows reusing the same pattern aliases for both a job filter and a queue step:
```yml
aliases:
  - &tag_pattern /^example-.*/
  
jobs:
  queue_job:
    steps:
      - queue/until_front_of_line:
          tag-pattern: *tag_pattern

workflows:
  version: 2

  example_workflow:
    jobs:
      - queue_job:
          filters:
            tags:
              only: *tag_pattern
```
- As a CircleCI orb, it makes sense to support syntax that is similar to that of CircleCI 
- Git tags/refs are not allowed to begin or end with a slash, so this change should not affect any existing patterns and be fully backward-compatible ([see item 6 here](https://git-scm.com/docs/git-check-ref-format)).

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
 
 - Remove wrapping slashes from the `tag-pattern` parameter
  
 I'm not sure how to write a test for this as I'm not really familiar with BATS or orb testing. 🙏 