### PR TITLE
[semver:patch] @orb.yml description to contain a requirement of `CIRCLECI_API_KEY`

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -4,6 +4,7 @@ description: |
   This is ideal for deployments or other activities that must not run concurrently.
   May optionaly consider branch-level isolation if unique branches should run concurrently. 
   This orb requires the project to have an API key in order to query build states.
+  It requires a single environment variable CIRCLECI_API_KEY which can be created in account settings - https://circleci.com/account/api.
 
   1.6.3: addresses API changes that broke branch-job queueing, adds more API checks
   1.6.1: fixes issue in tag matching , thanks @calvin-summer


### PR DESCRIPTION
Reading https://circleci.com/developer/orbs/orb/eddiewebb/queue doesn't give a clear information that this env is required.
