### PR TITLE
[Merged by Bors] - Allow job_regex as additional paramter [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: Publish Dev
           command: |
-            PUBLISH_MESSAGE=`circleci orb publish packed.yml eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>>--token ${CIRCLECI_API_KEY}`
+            PUBLISH_MESSAGE=`circleci orb publish packed.yml eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> --token ${CIRCLECI_API_KEY}`
             ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb `\(.*\)` was published.*/\1/p')
             echo "export ORB_VERSION=\"${ORB_VERSION}\"" >> $BASH_ENV
             echo $ORB_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: Publish Dev
           command: |
-            PUBLISH_MESSAGE=`circleci orb publish packed.yml eddiewebb/<<pipeline.parameters.orbname>>@dev:${PR_NUMBER} --token ${CIRCLECI_API_KEY}`
+            PUBLISH_MESSAGE=`circleci orb publish packed.yml eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>>--token ${CIRCLECI_API_KEY}`
             ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb `\(.*\)` was published.*/\1/p')
             echo "export ORB_VERSION=\"${ORB_VERSION}\"" >> $BASH_ENV
             echo $ORB_VERSION
@@ -62,7 +62,7 @@ jobs:
       - run:
           name: Import Tests using BATS
           command: |
-            export BATS_IMPORT_DEV_ORB="eddiewebb/<<pipeline.parameters.orbname>>@dev:${PR_NUMBER}"
+            export BATS_IMPORT_DEV_ORB="eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>>"
             bats test            
       - pr-comment
 
@@ -86,7 +86,7 @@ jobs:
               echo "export PR_MESSAGE=\"Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
               exit 0
             else
-              PUBLISH_MESSAGE=`circleci orb publish promote eddiewebb/<<pipeline.parameters.orbname>>@dev:${PR_NUMBER} ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
+              PUBLISH_MESSAGE=`circleci orb publish promote eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
               echo $PUBLISH_MESSAGE
               ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
               echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,4 @@
 status = [
   'build-deploy'
 ]
+use_squash_merge = true

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,7 +6,10 @@ description: |
   This orb requires the project to have an API key in order to query build states.
   It requires a single environment variable CIRCLECI_API_KEY which can be created in account settings - https://circleci.com/account/api.
 
-  1.6.4: adds regexp for job names
+
+  1.7.0: adds regexp for job names, collab with @jonesie100
+  1.6.5: docs contribution by @pwilczynskiclearcode 
+  1.6.4: support slashes in Tags, thanks @dunial
   1.6.3: addresses API changes that broke branch-job queueing, adds more API checks
   1.6.1: fixes issue in tag matching , thanks @calvin-summer
   1.6.0: Support Tags, thanks @nikolaik, @dunial

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,6 +6,7 @@ description: |
   This orb requires the project to have an API key in order to query build states.
   It requires a single environment variable CIRCLECI_API_KEY which can be created in account settings - https://circleci.com/account/api.
 
+  1.6.4: adds regexp for job names
   1.6.3: addresses API changes that broke branch-job queueing, adds more API checks
   1.6.1: fixes issue in tag matching , thanks @calvin-summer
   1.6.0: Support Tags, thanks @nikolaik, @dunial
@@ -74,3 +75,25 @@ examples:
                 time: "10"                # max wait, in minutes (default 10)
                 only-on-branch: master  # restrict queueing to a specific branch (default *)
             - run: echo "This job will not overlap"
+  
+  multiple_job_names_regexp:
+    description: Use regexp-jobname when you have multiple jobs to block order of.
+    usage:
+      version: 2.1
+      orbs:
+        queue: eddiewebb/queue@volatile
+
+      workflows:
+        build_deploy:
+          jobs:
+            - queue/block_workflow:
+                name: conductor
+                time: "10"                
+                only-on-branch: master  
+                job-regex: "^DeployStep[0-9]$"
+            - DeployStep1:
+                requires: conductor
+            - DeployStep2:
+                requires: conductor
+            - SomeOtherLongJobWeDontCareAbout
+

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -86,14 +86,33 @@ examples:
       workflows:
         build_deploy:
           jobs:
-            - queue/block_workflow:
-                name: conductor
-                time: "10"                
-                only-on-branch: master  
-                job-regex: "^DeployStep[0-9]$"
+            - build
             - DeployStep1:
-                requires: conductor
+                requires:
+                  - build
             - DeployStep2:
-                requires: conductor
-            - SomeOtherLongJobWeDontCareAbout
+                requires:
+                  - DeployStep1
+      jobs:
+        build:
+          docker:
+            - image: circleci/node:10
+          steps:
+            - run: echo "This job can overlap"
+
+        DeployStep1:
+          docker:
+            - image: circleci/node:10
+          steps:
+            - queue/until_front_of_line:
+                time: "10"               
+                only-on-branch: master  
+                job-regex: "^DeployStep[0-9]$" #use extendex regexp pattern 
+            - run: echo "This job will not overlap with itself or next similar nameds job"
+
+        DeployStep2:
+          docker:
+            - image: circleci/node:10
+          steps:
+            - run: echo "This job will block step1 on any further workflows"
 

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -139,9 +139,9 @@ steps:
 
           load_current_workflow_values
           
-          job_name="${CIRCLE_JOB}"
+          JOB_NAME="${CIRCLE_JOB}"
           if [ "<<parameters.job-regex>>" ] ;then
-            job_name="<<parameters.job-regex>>"
+            JOB_NAME="<<parameters.job-regex>>"
           fi
 
           # falsey parameters are empty strings, so always compare against 'true' 
@@ -152,9 +152,9 @@ steps:
             oldest_commit_time=`jq 'sort_by(.workflows.created_at)| .[0].workflows.created_at' /tmp/augmented_jobstatus.json`
           else
             echo "Orb parameter block-workflow is false."
-            echo "Only blocking execution if running previous jobs matching this job: $job_name"
-            oldest_running_build_num=`jq ". | map(select(.workflows.job_name | grep -Eq $job_name)) | sort_by(.workflows.created_at)|  .[0].build_num" /tmp/augmented_jobstatus.json`
-            oldest_commit_time=`jq ". | map(select(.workflows.job_name | grep -Eq $job_name)) | sort_by(.workflows.created_at)|  .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
+            echo "Only blocking execution if running previous jobs matching this job: ${JOB_NAME}"
+            oldest_running_build_num=`jq ". | map(select(.workflows.job_name | grep -Eq ${JOB_NAME})) | sort_by(.workflows.created_at)|  .[0].build_num" /tmp/augmented_jobstatus.json`
+            oldest_commit_time=`jq ". | map(select(.workflows.job_name | grep -Eq ${JOB_NAME})) | sort_by(.workflows.created_at)|  .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
           fi
           if [ -z "$oldest_commit_time" ]; then
             echo "API Error - unable to load previous job timings. Report to developer."

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -140,8 +140,8 @@ steps:
           load_current_workflow_values
           
           job_name="${CIRCLE_JOB}"
-          if [ "<<parameters.job_regex>>" ] ;then
-            job_name="<<parameters.job_regex>>"
+          if [ "<<parameters.job-regex>>" ] ;then
+            job_name="<<parameters.job-regex>>"
           fi
 
           # falsey parameters are empty strings, so always compare against 'true' 

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -36,7 +36,7 @@ parameters:
     type: string
     default: ""
     description: "Set to queue jobs using a regex pattern f.ex '^v[0-9]+\\.[0-9]+\\.[0-9]+$' to filter CIRCLECI_TAG"
-  branch-regex:
+  job-regex:
     type: string
     default: ""
     description: "Allow multiple job names to be blocked until front of line f.ex '^runTests*'
@@ -153,8 +153,8 @@ steps:
           else
             echo "Orb parameter block-workflow is false."
             echo "Only blocking execution if running previous jobs matching this job: $job_name"
-            oldest_running_build_num=`jq ". | map(select(.workflows.job_name==\"$job_name\")) | sort_by(.workflows.created_at)|  .[0].build_num" /tmp/augmented_jobstatus.json`
-            oldest_commit_time=`jq ". | map(select(.workflows.job_name==\"$job_name\")) | sort_by(.workflows.created_at)|  .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
+            oldest_running_build_num=`jq ". | map(select(.workflows.job_name | grep -Eq $job_name)) | sort_by(.workflows.created_at)|  .[0].build_num" /tmp/augmented_jobstatus.json`
+            oldest_commit_time=`jq ". | map(select(.workflows.job_name | grep -Eq $job_name)) | sort_by(.workflows.created_at)|  .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
           fi
           if [ -z "$oldest_commit_time" ]; then
             echo "API Error - unable to load previous job timings. Report to developer."

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -39,7 +39,7 @@ parameters:
   job-regex:
     type: string
     default: ""
-    description: "Allow multiple job names to be blocked until front of line f.ex '^runTests*'
+    description: "Allow multiple job names to be blocked until front of line f.ex '^runTests*'"
 steps:
   - run:
       name: Queue Until Front of Line

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -36,6 +36,10 @@ parameters:
     type: string
     default: ""
     description: "Set to queue jobs using a regex pattern f.ex '^v[0-9]+\\.[0-9]+\\.[0-9]+$' to filter CIRCLECI_TAG"
+  branch-regex:
+    type: string
+    default: ""
+    description: "Allow multiple job names to be blocked until front of line f.ex '^runTests*'
 steps:
   - run:
       name: Queue Until Front of Line
@@ -134,6 +138,11 @@ steps:
           fetch_active_workflows
 
           load_current_workflow_values
+          
+          job_name="${CIRCLE_JOB}"
+          if [ "<<parameters.job_regex>>" ] ;then
+            job_name="<<parameters.job_regex>>"
+          fi
 
           # falsey parameters are empty strings, so always compare against 'true' 
           if [ "<<parameters.block-workflow>>" = "true" ] ;then
@@ -143,9 +152,9 @@ steps:
             oldest_commit_time=`jq 'sort_by(.workflows.created_at)| .[0].workflows.created_at' /tmp/augmented_jobstatus.json`
           else
             echo "Orb parameter block-workflow is false."
-            echo "Only blocking execution if running previous jobs matching this job: ${CIRCLE_JOB}"
-            oldest_running_build_num=`jq ". | map(select(.workflows.job_name==\"${CIRCLE_JOB}\")) | sort_by(.workflows.created_at)|  .[0].build_num" /tmp/augmented_jobstatus.json`
-            oldest_commit_time=`jq ". | map(select(.workflows.job_name==\"${CIRCLE_JOB}\")) | sort_by(.workflows.created_at)|  .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
+            echo "Only blocking execution if running previous jobs matching this job: $job_name"
+            oldest_running_build_num=`jq ". | map(select(.workflows.job_name==\"$job_name\")) | sort_by(.workflows.created_at)|  .[0].build_num" /tmp/augmented_jobstatus.json`
+            oldest_commit_time=`jq ". | map(select(.workflows.job_name==\"$job_name\")) | sort_by(.workflows.created_at)|  .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
           fi
           if [ -z "$oldest_commit_time" ]; then
             echo "API Error - unable to load previous job timings. Report to developer."

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -59,6 +59,7 @@ steps:
           if [ $http_response != "200" ]; then
               echo "ERROR: Server returned error code: $http_response"
               cat ${target}
+              exit 1
           else
               echo "DEBUG: API Success"
           fi
@@ -153,8 +154,8 @@ steps:
           else
             echo "Orb parameter block-workflow is false."
             echo "Only blocking execution if running previous jobs matching this job: ${JOB_NAME}"
-            oldest_running_build_num=`jq ". | map(select(.workflows.job_name | grep -Eq ${JOB_NAME})) | sort_by(.workflows.created_at)|  .[0].build_num" /tmp/augmented_jobstatus.json`
-            oldest_commit_time=`jq ". | map(select(.workflows.job_name | grep -Eq ${JOB_NAME})) | sort_by(.workflows.created_at)|  .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
+            oldest_running_build_num=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.workflows.created_at)|  .[0].build_num" /tmp/augmented_jobstatus.json`
+            oldest_commit_time=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.workflows.created_at)|  .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
           fi
           if [ -z "$oldest_commit_time" ]; then
             echo "API Error - unable to load previous job timings. Report to developer."

--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -32,6 +32,10 @@ parameters:
     type: env_var_name
     default: CIRCLECI_API_KEY
     description: "In case you use a different Environment Variable Name than CIRCLECI_API_KEY, supply it here."
+  job-regex:
+    type: string
+    default: ""
+    description: "Allow multiple job names to be blocked until front of line f.ex '^runTests*'"
 
 docker:
   - image: cimg/base:stable
@@ -46,3 +50,4 @@ steps:
       vcs-type: <<parameters.vcs-type>>
       confidence: <<parameters.confidence>>
       circleci-api-key: <<parameters.circleci-api-key>>
+      job-regex: <<parameters.job-regex>>

--- a/test/api/jobs/regex-matches.json
+++ b/test/api/jobs/regex-matches.json
@@ -1,0 +1,62 @@
+[
+
+{
+  "testing-note":"This represents the current build, with a job that should be serial",
+  "build_num" : 2,
+  "committer_date": "2019-01-17T11:17:24-05:00",
+  "branch" : "master",
+  "build_parameters":{
+  },
+  "workflows" : {
+    "job_name" : "DeployStep1",
+    "job_id" : "random-hash-2",
+    "workflow_id" : "ec6172d3-b286-4d3a-a1da-c4efba0a0c05",
+    "workspace_id" : "a1892dee-6e9e-4f2e-adbc-a5629a97b483",
+    "upstream_job_ids" : [ ],
+    "upstream_concurrency_map" : { },
+    "workflow_name" : "build-deploy"
+  },
+  "status" : "running"
+},
+
+{
+  "testing-note":"This represents a previous deploy job with max concurreny of 1, Delete this block while local testing is queued to mimic previous build completing",
+  "build_num" : 3,
+  "committer_date": "2019-01-17T10:17:24-05:00",
+  "branch" : "master",
+  "build_parameters":{
+  },
+  "workflows" : {
+    "job_name" : "DeployStep2",
+    "job_id" : "random-hash-3",
+    "workflow_id" : "aaa8751e-eb0d-4b09-12bd-06a9bb763771",
+    "workspace_id" : "a1892dee-6e9e-4f2e-adbc-a5629a97b483",
+    "upstream_job_ids" : [ ],
+    "upstream_concurrency_map" : { },
+    "workflow_name" : "build-deploy"
+  },
+  "status" : "running"
+}
+,
+
+{
+  "testing-note":"This represents a previous deploy job with max concurreny of 1, Delete this block while local testing is queued to mimic previous build completing",
+  "build_num" : 4,
+  "committer_date": "2019-01-17T10:17:25-05:00",
+  "branch" : "master",
+  "build_parameters":{
+  },
+  "workflows" : {
+    "job_name" : "SafeBuildJob",
+    "job_id" : "random-hash-4",
+    "workflow_id" : "aaa8751e-eb0d-4b09-12bd-06a9bb763771",
+    "workspace_id" : "a1892dee-6e9e-4f2e-adbc-a5629a97b483",
+    "upstream_job_ids" : [ ],
+    "upstream_concurrency_map" : { },
+    "workflow_name" : "build-deploy"
+  },
+  "status" : "running"
+}
+
+
+]

--- a/test/inputs/command-job-regexp-nomatch.yml
+++ b/test/inputs/command-job-regexp-nomatch.yml
@@ -1,0 +1,10 @@
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/repo
+    steps:
+      - queue/until_front_of_line:
+          time: "1"
+          only-on-branch: "master"
+          job-regex: "^BuildStep*"

--- a/test/inputs/command-job-regexp.yml
+++ b/test/inputs/command-job-regexp.yml
@@ -1,0 +1,10 @@
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/repo
+    steps:
+      - queue/until_front_of_line:
+          time: "1"
+          only-on-branch: "master"
+          job-regex: "^DeployStep[0-9]$"

--- a/test/test_expansion.bats
+++ b/test/test_expansion.bats
@@ -51,6 +51,33 @@ function setup {
 }
 
 
+@test "Command: script will NOT WAIT with previous job of non matching names when using regexp" {
+  # given
+  process_config_with test/inputs/command-job-regexp-nomatch.yml
+  export TESTING_MOCK_RESPONSE=test/api/jobs/regex-matches.json
+  export TESTING_MOCK_WORKFLOW_RESPONSES=test/api/workflows
+
+  # when
+  assert_jq_match '.jobs | length' 1 #only 1 job
+  assert_jq_match '.jobs["build"].steps | length' 1 #only 1 steps
+
+  jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
+
+  export CIRCLE_BUILD_NUM="2"
+  export CIRCLE_JOB="DeployJob1"
+  export CIRCLE_PROJECT_USERNAME="madethisup"
+  export CIRCLE_PROJECT_REPONAME="madethisup"
+  export CIRCLE_REPOSITORY_URL="madethisup"
+  export CIRCLE_BRANCH="master"
+  export CIRCLE_PR_REPONAME=""
+  run bash ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
+
+
+  assert_contains_text "Max Queue Time: 1 minutes"
+  assert_contains_text "Front of the line, WooHoo!, Build continuing"
+  [[ "$status" == "0" ]]
+}
+
 @test "Command: script will WAIT with previous job of similar name used in regexp" {
   # given
   process_config_with test/inputs/command-job-regexp.yml
@@ -92,7 +119,6 @@ function setup {
 
   jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
-  export CIRCLECI_API_KEY="madethisup"
   export CIRCLE_BUILD_NUM="2"
   export CIRCLE_JOB="singlejob"
   export CIRCLE_PROJECT_USERNAME="madethisup"
@@ -132,7 +158,6 @@ function setup {
 
   jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
-  export CIRCLECI_API_KEY="madethisup"
   export CIRCLE_BUILD_NUM="2"
   export CIRCLE_JOB="singlejob"
   export CIRCLE_PROJECT_USERNAME="madethisup"
@@ -161,7 +186,6 @@ function setup {
 
   jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
-  export CIRCLECI_API_KEY="madethisup"
   export CIRCLE_BUILD_NUM="2"
   export CIRCLE_JOB="singlejob"
   export CIRCLE_PROJECT_USERNAME="madethisup"
@@ -189,7 +213,6 @@ function setup {
 
   jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
-  export CIRCLECI_API_KEY="madethisup"
   export CIRCLE_BUILD_NUM="2"
   export CIRCLE_JOB="singlejob"
   export CIRCLE_PROJECT_USERNAME="madethisup"
@@ -219,7 +242,6 @@ function setup {
 
   jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
-  export CIRCLECI_API_KEY="madethisup"
   export CIRCLE_BUILD_NUM="2"
   export CIRCLE_JOB="singlejob"
   export CIRCLE_PROJECT_USERNAME="madethisup"
@@ -250,7 +272,6 @@ function setup {
 
   jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
-  export CIRCLECI_API_KEY="madethisup"
   export CIRCLE_BUILD_NUM="2"
   export CIRCLE_BRANCH="somespecialbranch"
   export CIRCLE_JOB="singlejob"
@@ -281,7 +302,6 @@ function setup {
 
   jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
-  export CIRCLECI_API_KEY="madethisup"
   export CIRCLE_BUILD_NUM="2"
   export CIRCLE_BRANCH="dev"
   export CIRCLE_JOB="singlejob"
@@ -310,7 +330,7 @@ function setup {
 
   jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
-  export CIRCLECI_API_KEY="madethisup"
+  
   export CIRCLE_BUILD_NUM="2"
   export CIRCLE_BRANCH="somespecialbranch"
   export CIRCLE_JOB="singlejob"
@@ -343,7 +363,7 @@ function setup {
 
   jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
-  export CIRCLECI_API_KEY="madethisup"
+  
   export CIRCLE_BUILD_NUM="2"
   export CIRCLE_JOB="singlejob"
   export CIRCLE_PROJECT_USERNAME="madethisup"
@@ -370,7 +390,7 @@ function setup {
 
   jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
-  export CIRCLECI_API_KEY="madethisup"
+  
   export CIRCLE_BUILD_NUM="2"
   export CIRCLE_JOB="singlejob"
   export CIRCLE_PROJECT_USERNAME="madethisup"
@@ -395,7 +415,7 @@ function setup {
 
   jq -r '.jobs["Single File"].steps[0].run.command' $JSON_PROJECT_CONFIG > ${BATS_TMPDIR}/script-${BATS_TEST_NUMBER}.bash
 
-  export CIRCLECI_API_KEY="madethisup"
+  
   export CIRCLE_BUILD_NUM="2"
   export CIRCLE_JOB="singlejob"
   export CIRCLE_PROJECT_USERNAME="madethisup"

--- a/test/test_expansion.bats
+++ b/test/test_expansion.bats
@@ -407,6 +407,8 @@ function setup {
 
 @test "Default job sets block workflow properly" {
   # given
+  export TESTING_MOCK_RESPONSE=test/api/jobs/onepreviousjob-differentname.json
+  export TESTING_MOCK_WORKFLOW_RESPONSES=test/api/workflows
   process_config_with test/inputs/fulljob.yml
 
   # when


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ X] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

I wan to queue multiple jobs with different names.  In the case of using CircleCI matrix we cannot change the name that is given to the job.  This is a blocker since we have to use matrix and queue/until_front_of_line is not queuing across job names.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
 Add job-regex paramter.  This allows us to use regex to match what jobs you want to queue on
