### PR TITLE
Remove fail flag from curl [semver:minor]

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -55,7 +55,7 @@ steps:
           echo "DEBUG: Making API Call to ${1}"
           url=$1
           target=$2
-          http_response=$(curl -f -s -X GET -H "Circle-Token:${<< parameters.circleci-api-key >>}" -o "${target}" -w "%{http_code}" "${url}")
+          http_response=$(curl -s -X GET -H "Circle-Token:${<< parameters.circleci-api-key >>}" -o "${target}" -w "%{http_code}" "${url}")
           if [ $http_response != "200" ]; then
               echo "ERROR: Server returned error code: $http_response"
               cat ${target}


### PR DESCRIPTION
The response code is checked anyway, so using the fail flag actually results in less helpful error messages.

### Checklist

Closes #85  thanks to header inclusion from #86 , thanks @kevinr-electric and @AlexMeuer 

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

We are seeing failures from the API when using this, but cannot debug since the `-f` flag for curl doesn't tell use the response code in the event of a failure.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
remove `-f` flag from curl statement
