### PR TITLE
[semver:patch] Add ContentType header to CircleCI requests

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -55,7 +55,7 @@ steps:
           echo "DEBUG: Making API Call to ${1}"
           url=$1
           target=$2
-          http_response=$(curl -f -s -X GET -H "Circle-Token:${<< parameters.circleci-api-key >>}" -o "${target}" -w "%{http_code}" "${url}")
+          http_response=$(curl -f -s -X GET -H "Circle-Token:${<< parameters.circleci-api-key >>}" -H "Content-Type: application/json" -o "${target}" -w "%{http_code}" "${url}")
           if [ $http_response != "200" ]; then
               echo "ERROR: Server returned error code: $http_response"
               cat ${target}


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Issue 80 points out that requests to the CircleCI API have started failing. Adding the ContentType header fixes this.

https://github.com/eddiewebb/circleci-queue/issues/85

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Added header `-H "Content-Type: application/json"` to curl request to in `fetch()`.
