### PR TITLE
fix(urlencode): urlencode CIRCLE_BRANCH [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,28 @@ jobs:
             export BATS_IMPORT_DEV_ORB="eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>>"
             bats test            
       - pr-comment
+      - run:
+          name: Check Semver
+          command: |
+            if [ "$PR_NUMBER" == "" ];then
+              echo "No pr found, do nothing"
+              exit 0
+            fi
+            TITLE=`curl -u eddiewebb:${GHI_TOKEN} "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}" | jq '.title' `
+            SEMVER_INCREMENT=`echo $TITLE | sed -En 's/.*\[semver:(major|minor|patch|skip)\].*/\1/p'`
+            if [ -z ${SEMVER_INCREMENT} ];then
+              echo "Merge commit did not indicate which SemVer increment to make. Please ammend commit with [semver:FOO] where FOO is major, minor, or patch"
+              exit 1
+            elif [ "$SEMVER_INCREMENT" == "skip" ];then
+              echo "SEMVER in commit indicated to skip orb release"
+              echo "export PR_MESSAGE=\"Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
+              exit 0
+            else
+              PUBLISH_MESSAGE=`circleci orb publish promote eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
+              echo $PUBLISH_MESSAGE
+              ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
+              echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV
+            fi         
 
   publish:
     docker:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,7 +6,8 @@ description: |
   This orb requires the project to have an API key in order to query build states.
   It requires a single environment variable CIRCLECI_API_KEY which can be created in account settings - https://circleci.com/account/api.
 
-
+  1.8.3: Doc update
+  1.8.2: Adds urlencode for branch names. (@andrew-barnett)
   1.8.1: Adds content-type header to API calls (@kevinr-electric) and prints message on error (@AlexMeuer)
   1.8.0: minor fix same as version 1.8.0 (missing docs)
   1.7.1: patch fix same as version 1.8.1 to catch folsk who dont update

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -51,6 +51,19 @@ steps:
           tag_pattern=${tag_pattern:1:-1}
         fi
 
+        urlencode(){
+          local LC_ALL=C
+          local c i n=${#1}
+          for (( i=0; i<n; i++ )); do
+            c="${1:i:1}"
+            case "$c" in
+              [-_.~A-Za-z0-9]) printf '%s' "$c" ;;
+              *) printf '%%%02X' "'$c" ;;
+            esac
+          done
+          echo
+        }
+
         fetch(){
           echo "DEBUG: Making API Call to ${1}"
           url=$1
@@ -95,7 +108,7 @@ steps:
           else
             : ${CIRCLE_BRANCH:?"Required Env Variable not found!"}
             echo "Only blocking execution if running previous jobs on branch: ${CIRCLE_BRANCH}"
-            jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/tree/${CIRCLE_BRANCH}?filter=running"
+            jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/tree/$(urlencode "${CIRCLE_BRANCH}")?filter=running"
           fi
 
           if [ ! -z $TESTING_MOCK_RESPONSE ] && [ -f $TESTING_MOCK_RESPONSE ];then

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -52,16 +52,20 @@ steps:
         fi
 
         urlencode(){
-          local LC_ALL=C
-          local c i n=${#1}
-          for (( i=0; i<n; i++ )); do
-            c="${1:i:1}"
-            case "$c" in
-              [-_.~A-Za-z0-9]) printf '%s' "$c" ;;
-              *) printf '%%%02X' "'$c" ;;
+          LC_WAS="${LC_ALL:-}"
+          export LC_ALL=C
+          string="$1"
+          while [ -n "$string" ]; do
+            tail="${string#?}"
+            head="${string%$tail}"
+            case "$head" in
+              [-_.~A-Za-z0-9]) printf '%c' "$head" ;;
+              *) printf '%%%02X' "'$head" ;;
             esac
+            string="${tail}"
           done
           echo
+          export LC_ALL="${LC_WAS}"
         }
 
         fetch(){


### PR DESCRIPTION
### Motivation, issues

The CircleCI API (started?) requiring urlencoded branch names, otherwise the calls were returning empty results. This caused the queue to never succeed. This fix urlencodes the branch name. See #89

### Description

add `urlencode` function and run `${CIRCLE_BRANCH}` through it while building branch-specific API url

fixes #89