### PR TITLE
Add custom hostname to support server customer use [semver:minor]

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,8 +6,9 @@ description: |
   This orb requires the project to have an API key in order to query build states.
   It requires a single environment variable CIRCLECI_API_KEY which can be created in account settings - https://circleci.com/account/api.
 
-  1.8.3: Doc update
-  1.8.2: Adds urlencode for branch names. (@andrew-barnett)
+  1.10.0: Adds Server Support (@nanophate)
+  1.9.0: Doc update
+  1.8.4: Adds urlencode for branch names. (@andrew-barnett)
   1.8.1: Adds content-type header to API calls (@kevinr-electric) and prints message on error (@AlexMeuer)
   1.8.0: minor fix same as version 1.8.0 (missing docs)
   1.7.1: patch fix same as version 1.8.1 to catch folsk who dont update

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -101,7 +101,7 @@ steps:
           else
             fetch "${CIRCLECI_BASE_URL}/api/v2/me" "/tmp/me.cci"
             me=$(jq -e '.id' /tmp/me.cci)
-            echo "Using API key for user: ${me}"
+            echo "Using API key for user: ${me} on host ${CIRCLECI_BASE_URL}"
           fi
           VCS_TYPE="<<parameters.vcs-type>>"
         }

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -40,6 +40,11 @@ parameters:
     type: string
     default: ""
     description: "Allow multiple job names to be blocked until front of line f.ex '^runTests*'"
+  circleci-hostname:
+    type: string
+    default: "https://circleci.com"
+    description: "For server user to specifiy custom hostname for their server"
+
 steps:
   - run:
       name: Queue Until Front of Line
@@ -93,7 +98,7 @@ steps:
           if [ -z "${<< parameters.circleci-api-key >>}" ]; then
             echo "<< parameters.circleci-api-key >> not set. Private projects will be inaccessible."
           else
-            fetch "https://circleci.com/api/v2/me" "/tmp/me.cci"
+            fetch "<< parameters.circleci-hostname >>/api/v2/me" "/tmp/me.cci"
             me=$(jq -e '.id' /tmp/me.cci)
             echo "Using API key for user: ${me}"
           fi
@@ -104,15 +109,15 @@ steps:
         fetch_filtered_active_builds(){
           if [ "<<parameters.consider-branch>>" != "true" ];then
             echo "Orb parameter 'consider-branch' is false, will block previous builds on any branch." 
-            jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?filter=running"
+            jobs_api_url_template="<< parameters.circleci-hostname >>/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?filter=running"
           elif [ -n "${CIRCLE_TAG:x}" ] && [ "$tag_pattern" != "" ]; then
             # I'm not sure why this is here, seems identical to above?
             echo "CIRCLE_TAG and orb parameter tag-pattern is set, fetch active builds"
-            jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?filter=running"
+            jobs_api_url_template="<< parameters.circleci-hostname >>/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?filter=running"
           else
             : ${CIRCLE_BRANCH:?"Required Env Variable not found!"}
             echo "Only blocking execution if running previous jobs on branch: ${CIRCLE_BRANCH}"
-            jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/tree/$(urlencode "${CIRCLE_BRANCH}")?filter=running"
+            jobs_api_url_template="<< parameters.circleci-hostname >>/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/tree/$(urlencode "${CIRCLE_BRANCH}")?filter=running"
           fi
 
           if [ ! -z $TESTING_MOCK_RESPONSE ] && [ -f $TESTING_MOCK_RESPONSE ];then
@@ -139,7 +144,7 @@ steps:
               echo "Using test mock workflow response"
               cat $TESTING_MOCK_WORKFLOW_RESPONSES/${workflow}.json > ${workflow_file}
             else
-              fetch "https://circleci.com/api/v2/workflow/${workflow}" "${workflow_file}"
+              fetch "<< parameters.circleci-hostname >>/api/v2/workflow/${workflow}" "${workflow_file}"
             fi
             created_at=`jq -r '.created_at' ${workflow_file}`
             echo "Workflow was created at: ${created_at}"
@@ -197,7 +202,7 @@ steps:
 
         cancel_current_build(){
           echo "Cancelleing build ${CIRCLE_BUILD_NUM}"
-          cancel_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/cancel?circle-token=${<< parameters.circleci-api-key >>}"
+          cancel_api_url_template="<< parameters.circleci-hostname >>/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/cancel?circle-token=${<< parameters.circleci-api-key >>}"
           curl -s -X POST $cancel_api_url_template > /dev/null
         }
 

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -42,7 +42,7 @@ parameters:
     description: "Allow multiple job names to be blocked until front of line f.ex '^runTests*'"
   circleci-hostname:
     type: string
-    default: "https://circleci.com"
+    default: "circleci.com"
     description: "For server user to specifiy custom hostname for their server"
 
 steps:
@@ -50,6 +50,7 @@ steps:
       name: Queue Until Front of Line
       command: |
         tag_pattern="<<parameters.tag-pattern>>"
+        CIRCLECI_BASE_URL="https://<<parameters.circleci-hostname>>"
 
         # If a pattern is wrapped with slashes, remove them.
         if [[ "$tag_pattern" == /*/ ]]; then
@@ -98,7 +99,7 @@ steps:
           if [ -z "${<< parameters.circleci-api-key >>}" ]; then
             echo "<< parameters.circleci-api-key >> not set. Private projects will be inaccessible."
           else
-            fetch "<< parameters.circleci-hostname >>/api/v2/me" "/tmp/me.cci"
+            fetch "${CIRCLECI_BASE_URL}/api/v2/me" "/tmp/me.cci"
             me=$(jq -e '.id' /tmp/me.cci)
             echo "Using API key for user: ${me}"
           fi
@@ -109,15 +110,15 @@ steps:
         fetch_filtered_active_builds(){
           if [ "<<parameters.consider-branch>>" != "true" ];then
             echo "Orb parameter 'consider-branch' is false, will block previous builds on any branch." 
-            jobs_api_url_template="<< parameters.circleci-hostname >>/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?filter=running"
+            jobs_api_url_template="${CIRCLECI_BASE_URL}/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?filter=running"
           elif [ -n "${CIRCLE_TAG:x}" ] && [ "$tag_pattern" != "" ]; then
             # I'm not sure why this is here, seems identical to above?
             echo "CIRCLE_TAG and orb parameter tag-pattern is set, fetch active builds"
-            jobs_api_url_template="<< parameters.circleci-hostname >>/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?filter=running"
+            jobs_api_url_template="${CIRCLECI_BASE_URL}/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?filter=running"
           else
             : ${CIRCLE_BRANCH:?"Required Env Variable not found!"}
             echo "Only blocking execution if running previous jobs on branch: ${CIRCLE_BRANCH}"
-            jobs_api_url_template="<< parameters.circleci-hostname >>/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/tree/$(urlencode "${CIRCLE_BRANCH}")?filter=running"
+            jobs_api_url_template="${CIRCLECI_BASE_URL}/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/tree/$(urlencode "${CIRCLE_BRANCH}")?filter=running"
           fi
 
           if [ ! -z $TESTING_MOCK_RESPONSE ] && [ -f $TESTING_MOCK_RESPONSE ];then
@@ -144,7 +145,7 @@ steps:
               echo "Using test mock workflow response"
               cat $TESTING_MOCK_WORKFLOW_RESPONSES/${workflow}.json > ${workflow_file}
             else
-              fetch "<< parameters.circleci-hostname >>/api/v2/workflow/${workflow}" "${workflow_file}"
+              fetch "${CIRCLECI_BASE_URL}/api/v2/workflow/${workflow}" "${workflow_file}"
             fi
             created_at=`jq -r '.created_at' ${workflow_file}`
             echo "Workflow was created at: ${created_at}"
@@ -202,7 +203,7 @@ steps:
 
         cancel_current_build(){
           echo "Cancelleing build ${CIRCLE_BUILD_NUM}"
-          cancel_api_url_template="<< parameters.circleci-hostname >>/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/cancel?circle-token=${<< parameters.circleci-api-key >>}"
+          cancel_api_url_template="${CIRCLECI_BASE_URL}/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/cancel?circle-token=${<< parameters.circleci-api-key >>}"
           curl -s -X POST $cancel_api_url_template > /dev/null
         }
 

--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -36,6 +36,10 @@ parameters:
     type: string
     default: ""
     description: "Allow multiple job names to be blocked until front of line f.ex '^runTests*'"
+  circleci-hostname:
+    type: string
+    default: "https://circleci.com"
+    description: "For server user to specifiy custom hostname for their server"
 
 docker:
   - image: cimg/base:stable
@@ -51,3 +55,4 @@ steps:
       confidence: <<parameters.confidence>>
       circleci-api-key: <<parameters.circleci-api-key>>
       job-regex: <<parameters.job-regex>>
+      circleci-hostname: <<parameters.circleci-hostname>>

--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -38,7 +38,7 @@ parameters:
     description: "Allow multiple job names to be blocked until front of line f.ex '^runTests*'"
   circleci-hostname:
     type: string
-    default: "https://circleci.com"
+    default: "circleci.com"
     description: "For server user to specifiy custom hostname for their server"
 
 docker:

--- a/test/bats_helper.bash
+++ b/test/bats_helper.bash
@@ -85,5 +85,14 @@ function assert_jq_match {
 	fi
 }
 
+function assert_jq_contains {
+	MATCH=$2
+	RES=$(jq -r "$1" ${JSON_PROJECT_CONFIG})
+	if [[ "$RES" != *"$MATCH"* ]];then
+		echo "Expected string "'"'"$MATCH"'"'" was not found in "'"'"$RES"'"'
+		return 1
+	fi
+}
+
 
 

--- a/test/inputs/command-server.yml
+++ b/test/inputs/command-server.yml
@@ -1,0 +1,9 @@
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/repo
+    steps:
+      - queue/until_front_of_line:
+          time: "1"
+          circleci-hostname: example.com

--- a/test/test_expansion.bats
+++ b/test/test_expansion.bats
@@ -51,6 +51,22 @@ function setup {
 }
 
 
+@test "Command: Server hostname is respected by command" {
+  # given
+  process_config_with test/inputs/command-server.yml
+
+  # when
+  assert_jq_match '.jobs | length' 1 #only 1 job
+  assert_jq_match '.jobs["build"].steps | length' 1 #only 1 steps
+  assert_jq_contains '.jobs["build"].steps[0].run.command' "CIRCLECI_BASE_URL=\"https://example.com\"" #only 1 steps
+
+  run jq -r '.jobs["build"].steps[0].run.command' $JSON_PROJECT_CONFIG
+
+  assert_contains_text "max_time=1"
+
+}
+
+
 @test "Command: script will NOT WAIT with previous job of non matching names when using regexp" {
   # given
   process_config_with test/inputs/command-job-regexp-nomatch.yml


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

close: #91 

This change will help server user to also use this orb on their own hosted server.


### Description

Replaced the `https://circleci.com` to use a pipeline parameters. 
Added pipeline parameter default to be `https://circleci.com` so that cloud customer would not get this impact. 
