### PR TITLE
Add workflow as a queue target [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
   validate:
     docker:
       - image: cimg/base:2019.08
+    resource_class: small
     working_directory: ~/repo
     steps:
       - checkout
@@ -44,6 +45,7 @@ jobs:
   test:
     docker:
       - image: cimg/base:2019.08
+    resource_class: small
     working_directory: ~/repo
     steps:
       - checkout
@@ -53,7 +55,7 @@ jobs:
       - run:
           name: Publish Dev
           command: |
-            PUBLISH_MESSAGE=`circleci orb publish packed.yml eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> --token ${CIRCLECI_API_KEY}`
+            PUBLISH_MESSAGE=`circleci orb publish packed.yml soniqua/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> --token ${CIRCLECI_API_KEY}`
             ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb `\(.*\)` was published.*/\1/p')
             echo "export ORB_VERSION=\"${ORB_VERSION}\"" >> $BASH_ENV
             echo $ORB_VERSION
@@ -62,31 +64,31 @@ jobs:
       - run:
           name: Import Tests using BATS
           command: |
-            export BATS_IMPORT_DEV_ORB="eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>>"
+            export BATS_IMPORT_DEV_ORB="soniqua/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>>"
             bats test            
-      - pr-comment
-      - run:
-          name: Check Semver
-          command: |
-            if [ "$PR_NUMBER" == "" ];then
-              echo "No pr found, do nothing"
-              exit 0
-            fi
-            TITLE=`curl -u eddiewebb:${GHI_TOKEN} "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}" | jq '.title' `
-            SEMVER_INCREMENT=`echo $TITLE | sed -En 's/.*\[semver:(major|minor|patch|skip)\].*/\1/p'`
-            if [ -z ${SEMVER_INCREMENT} ];then
-              echo "Merge commit did not indicate which SemVer increment to make. Please ammend commit with [semver:FOO] where FOO is major, minor, or patch"
-              exit 1
-            elif [ "$SEMVER_INCREMENT" == "skip" ];then
-              echo "SEMVER in commit indicated to skip orb release"
-              echo "export PR_MESSAGE=\"Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
-              exit 0
-            else
-              PUBLISH_MESSAGE=`circleci orb publish promote eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
-              echo $PUBLISH_MESSAGE
-              ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
-              echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV
-            fi         
+      # - pr-comment
+      # - run:
+      #     name: Check Semver
+      #     command: |
+      #       if [ "$PR_NUMBER" == "" ];then
+      #         echo "No pr found, do nothing"
+      #         exit 0
+      #       fi
+      #       TITLE=`curl -u soniqua:${GHI_TOKEN} "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}" | jq '.title' `
+      #       SEMVER_INCREMENT=`echo $TITLE | sed -En 's/.*\[semver:(major|minor|patch|skip)\].*/\1/p'`
+      #       if [ -z ${SEMVER_INCREMENT} ];then
+      #         echo "Merge commit did not indicate which SemVer increment to make. Please ammend commit with [semver:FOO] where FOO is major, minor, or patch"
+      #         exit 1
+      #       elif [ "$SEMVER_INCREMENT" == "skip" ];then
+      #         echo "SEMVER in commit indicated to skip orb release"
+      #         echo "export PR_MESSAGE=\"Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
+      #         exit 0
+      #       else
+      #         PUBLISH_MESSAGE=`circleci orb publish promote soniqua/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
+      #         echo $PUBLISH_MESSAGE
+      #         ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
+      #         echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV
+      #       fi         
 
   publish:
     docker:
@@ -108,7 +110,7 @@ jobs:
               echo "export PR_MESSAGE=\"Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
               exit 0
             else
-              PUBLISH_MESSAGE=`circleci orb publish promote eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
+              PUBLISH_MESSAGE=`circleci orb publish promote soniqua/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
               echo $PUBLISH_MESSAGE
               ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
               echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV
@@ -153,7 +155,7 @@ commands:
             circleci config pack src/ > packed.yml
             circleci orb validate packed.yml
   pr-comment:
-    description: add nessage to pr this build originated from
+    description: add message to pr this build originated from
     steps:
       - run:
           name: Publish Version to PR
@@ -162,7 +164,7 @@ commands:
               echo "No pr found, do nothing"
               exit 0
             fi
-            curl -X POST -u eddiewebb:${GHI_TOKEN} "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"${PR_MESSAGE}\"}"
+            curl -X POST -u soniqua:${GHI_TOKEN} "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"${PR_MESSAGE}\"}"
   pr-info:
     description: get PR number this change originated from
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,6 @@ jobs:
   validate:
     docker:
       - image: cimg/base:2019.08
-    resource_class: small
     working_directory: ~/repo
     steps:
       - checkout
@@ -45,7 +44,6 @@ jobs:
   test:
     docker:
       - image: cimg/base:2019.08
-    resource_class: small
     working_directory: ~/repo
     steps:
       - checkout
@@ -55,7 +53,7 @@ jobs:
       - run:
           name: Publish Dev
           command: |
-            PUBLISH_MESSAGE=`circleci orb publish packed.yml soniqua/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> --token ${CIRCLECI_API_KEY}`
+            PUBLISH_MESSAGE=`circleci orb publish packed.yml eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> --token ${CIRCLECI_API_KEY}`
             ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb `\(.*\)` was published.*/\1/p')
             echo "export ORB_VERSION=\"${ORB_VERSION}\"" >> $BASH_ENV
             echo $ORB_VERSION
@@ -64,31 +62,31 @@ jobs:
       - run:
           name: Import Tests using BATS
           command: |
-            export BATS_IMPORT_DEV_ORB="soniqua/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>>"
+            export BATS_IMPORT_DEV_ORB="eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>>"
             bats test            
-      # - pr-comment
-      # - run:
-      #     name: Check Semver
-      #     command: |
-      #       if [ "$PR_NUMBER" == "" ];then
-      #         echo "No pr found, do nothing"
-      #         exit 0
-      #       fi
-      #       TITLE=`curl -u soniqua:${GHI_TOKEN} "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}" | jq '.title' `
-      #       SEMVER_INCREMENT=`echo $TITLE | sed -En 's/.*\[semver:(major|minor|patch|skip)\].*/\1/p'`
-      #       if [ -z ${SEMVER_INCREMENT} ];then
-      #         echo "Merge commit did not indicate which SemVer increment to make. Please ammend commit with [semver:FOO] where FOO is major, minor, or patch"
-      #         exit 1
-      #       elif [ "$SEMVER_INCREMENT" == "skip" ];then
-      #         echo "SEMVER in commit indicated to skip orb release"
-      #         echo "export PR_MESSAGE=\"Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
-      #         exit 0
-      #       else
-      #         PUBLISH_MESSAGE=`circleci orb publish promote soniqua/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
-      #         echo $PUBLISH_MESSAGE
-      #         ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
-      #         echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV
-      #       fi         
+      - pr-comment
+      - run:
+          name: Check Semver
+          command: |
+            if [ "$PR_NUMBER" == "" ];then
+              echo "No pr found, do nothing"
+              exit 0
+            fi
+            TITLE=`curl -u eddiewebb:${GHI_TOKEN} "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}" | jq '.title' `
+            SEMVER_INCREMENT=`echo $TITLE | sed -En 's/.*\[semver:(major|minor|patch|skip)\].*/\1/p'`
+            if [ -z ${SEMVER_INCREMENT} ];then
+              echo "Merge commit did not indicate which SemVer increment to make. Please ammend commit with [semver:FOO] where FOO is major, minor, or patch"
+              exit 1
+            elif [ "$SEMVER_INCREMENT" == "skip" ];then
+              echo "SEMVER in commit indicated to skip orb release"
+              echo "export PR_MESSAGE=\"Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
+              exit 0
+            else
+              PUBLISH_MESSAGE=`circleci orb publish promote eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
+              echo $PUBLISH_MESSAGE
+              ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
+              echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV
+            fi         
 
   publish:
     docker:
@@ -110,7 +108,7 @@ jobs:
               echo "export PR_MESSAGE=\"Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
               exit 0
             else
-              PUBLISH_MESSAGE=`circleci orb publish promote soniqua/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
+              PUBLISH_MESSAGE=`circleci orb publish promote eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
               echo $PUBLISH_MESSAGE
               ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
               echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV
@@ -164,7 +162,7 @@ commands:
               echo "No pr found, do nothing"
               exit 0
             fi
-            curl -X POST -u soniqua:${GHI_TOKEN} "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"${PR_MESSAGE}\"}"
+            curl -X POST -u eddiewebb:${GHI_TOKEN} "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"${PR_MESSAGE}\"}"
   pr-info:
     description: get PR number this change originated from
     steps:

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -20,6 +20,10 @@ parameters:
     type: string
     default: "*"
     description: "Only queue on specified branch"
+  only-on-workflow:
+    type: string
+    default: "*"
+    description: "Only queue on a specified workflow. Consider combining this with `consider-branch`:`false`."
   vcs-type:
     type: string
     default: "github"
@@ -171,9 +175,16 @@ steps:
           # falsey parameters are empty strings, so always compare against 'true' 
           if [ "<<parameters.block-workflow>>" = "true" ] ;then
             echo "Orb parameter block-workflow is true."
-            echo "This job will block until no previous workflows have *any* jobs running."
-            oldest_running_build_num=`jq 'sort_by(.workflows.created_at)| .[0].build_num' /tmp/augmented_jobstatus.json`
-            oldest_commit_time=`jq 'sort_by(.workflows.created_at)| .[0].workflows.created_at' /tmp/augmented_jobstatus.json`
+            if [ "<<parameters.only-on-workflow>>" = "*" ]; then
+              echo "This job will block until no previous workflows have *any* jobs running."
+              oldest_running_build_num=`jq 'sort_by(.workflows.created_at)| .[0].build_num' /tmp/augmented_jobstatus.json`
+              oldest_commit_time=`jq 'sort_by(.workflows.created_at)| .[0].workflows.created_at' /tmp/augmented_jobstatus.json`
+            else
+              echo "Orb parameter only-on-workflow is true."
+              echo "This job will block until no previous occurrences of workflow <<parameters.only-on-workflow>> have *any* jobs running."
+              oldest_running_build_num=`jq ". | map(select(.workflows.workflow_name| test(\"<<parameters.only-on-workflow>>\";\"sx\"))) | sort_by(.workflows.created_at)| .[0].build_num" /tmp/augmented_jobstatus.json`
+              oldest_commit_time=`jq ". | map(select(.workflows.workflow_name| test(\"<<parameters.only-on-workflow>>\";\"sx\"))) | sort_by(.workflows.created_at)| .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
+            fi
           else
             echo "Orb parameter block-workflow is false."
             echo "Only blocking execution if running previous jobs matching this job: ${JOB_NAME}"
@@ -191,7 +202,7 @@ steps:
             cat /tmp/jobstatus.json || exit 0
             echo "All running jobs with created_at:"
             cat /tmp/augmented_jobstatus.json || exit 0
-            echo "All worfklow details."
+            echo "All workflow details."
             cat /tmp/workflow-*.json
             exit 1
           fi
@@ -202,7 +213,7 @@ steps:
         }
 
         cancel_current_build(){
-          echo "Cancelleing build ${CIRCLE_BUILD_NUM}"
+          echo "Cancelling build ${CIRCLE_BUILD_NUM}"
           cancel_api_url_template="${CIRCLECI_BASE_URL}/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/cancel?circle-token=${<< parameters.circleci-api-key >>}"
           curl -s -X POST $cancel_api_url_template > /dev/null
         }
@@ -245,7 +256,7 @@ steps:
           echo "Oldest Workflow Timestamp: $oldest_commit_time"
           if [[ ! -z "$my_commit_time" ]] && [[ "$oldest_commit_time" > "$my_commit_time" || "$oldest_commit_time" = "$my_commit_time" ]] ; then
             # API returns Y-M-D HH:MM (with 24 hour clock) so alphabetical string compare is accurate to timestamp compare as well
-            # recent-jobs API does not include pending, so it is posisble we queried in between a workfow transition, and we;re NOT really front of line.
+            # recent-jobs API does not include pending, so it is possible we queried in between a workflow transition, and we;re NOT really front of line.
             if [ $confidence -lt <<parameters.confidence>> ];then
               # To grow confidence, we check again with a delay.
               confidence=$((confidence+1))

--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -20,6 +20,10 @@ parameters:
     type: string
     default: "*"
     description: "Only queue on specified branch. Default is to enforce serialization on all branches."
+  only-on-workflow:
+    type: string
+    default: "*"
+    description: "Only queue on a specified workflow. Consider combining this with `consider-branch`:`false`."
   vcs-type:
     type: string
     default: "github"
@@ -50,6 +54,7 @@ steps:
       block-workflow: <<parameters.block-workflow>>
       time: <<parameters.time>>
       dont-quit: <<parameters.dont-quit>>
+      only-on-workflow: <<parameters.only-on-workflow>>
       only-on-branch: <<parameters.only-on-branch>>
       vcs-type: <<parameters.vcs-type>>
       confidence: <<parameters.confidence>>

--- a/test/inputs/command-only-workflow.yml
+++ b/test/inputs/command-only-workflow.yml
@@ -1,0 +1,12 @@
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/repo
+    steps:
+      - queue/until_front_of_line:
+          # only on workflow
+          consider-branch: false
+          block-workflow: true
+          only-on-workflow: "build-deploy"
+          time: "1"


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

This change allows users to wait for no occurrences of a target `workflow` to complete.

This enables pull-request style checks to be executed across multiple open PRs, without the workflows conflicting.

Relates to (but may not close) #76.

### Description

add `only-on-workflow` to the orb.
- Specify a `workflow` name here for the queue orb to wait for all occurrences of a workflow to finish.
- If specified in conjunction with `consider-branch: false` waits for all occurrences of a workflow across all branches to finish.
