### PR TITLE
version catchup [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,15 +77,6 @@ jobs:
             if [ -z ${SEMVER_INCREMENT} ];then
               echo "Merge commit did not indicate which SemVer increment to make. Please ammend commit with [semver:FOO] where FOO is major, minor, or patch"
               exit 1
-            elif [ "$SEMVER_INCREMENT" == "skip" ];then
-              echo "SEMVER in commit indicated to skip orb release"
-              echo "export PR_MESSAGE=\"Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
-              exit 0
-            else
-              PUBLISH_MESSAGE=`circleci orb publish promote eddiewebb/<<pipeline.parameters.orbname>>@dev:<<pipeline.number>> ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
-              echo $PUBLISH_MESSAGE
-              ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
-              echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV
             fi         
 
   publish:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,6 +6,8 @@ description: |
   This orb requires the project to have an API key in order to query build states.
   It requires a single environment variable CIRCLECI_API_KEY which can be created in account settings - https://circleci.com/account/api.
 
+
+  2.0.0: Breaking change fixes dyanamic config, but drops some BB users.
   1.10.0: Adds Server Support (@nanophate)
   1.9.0: Doc update
   1.8.4: Adds urlencode for branch names. (@andrew-barnett)

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,7 +8,7 @@ description: |
 
   2.2.1: fixes release version bug
   2.2.0: Adds 'filter-by-workflow' (@soniqua)
-  2.0.0: Breaking change fixes dyanamic config, but drops some BB users. 
+  2.0.0: Breaking change fixes dyanamic config, but may break Bitbucket users. 
   1.12.0: Adds Server Support (@nanophate)
   1.9.0: Doc update
   1.8.4: Adds urlencode for branch names. (@andrew-barnett)

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,9 +6,10 @@ description: |
   This orb requires the project to have an API key in order to query build states.
   It requires a single environment variable CIRCLECI_API_KEY which can be created in account settings - https://circleci.com/account/api.
 
-
-  2.0.0: Breaking change fixes dyanamic config, but drops some BB users.
-  1.10.0: Adds Server Support (@nanophate)
+  2.2.1: fixes release version bug
+  2.2.0: Adds 'filter-by-workflow' (@soniqua)
+  2.0.0: Breaking change fixes dyanamic config, but drops some BB users. 
+  1.12.0: Adds Server Support (@nanophate)
   1.9.0: Doc update
   1.8.4: Adds urlencode for branch names. (@andrew-barnett)
   1.8.1: Adds content-type header to API calls (@kevinr-electric) and prints message on error (@AlexMeuer)

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -172,13 +172,13 @@ steps:
           if [ "<<parameters.block-workflow>>" = "true" ] ;then
             echo "Orb parameter block-workflow is true."
             echo "This job will block until no previous workflows have *any* jobs running."
-            oldest_running_build_num=`jq 'sort_by(.workflows.created_at)| .[0].build_num' /tmp/augmented_jobstatus.json`
-            oldest_commit_time=`jq 'sort_by(.workflows.created_at)| .[0].workflows.created_at' /tmp/augmented_jobstatus.json`
+            oldest_running_build_num=`jq 'sort_by(.committer_date)| .[0].build_num' /tmp/augmented_jobstatus.json`
+            oldest_commit_time=`jq 'sort_by(.committer_date)| .[0].committer_date' /tmp/augmented_jobstatus.json`
           else
             echo "Orb parameter block-workflow is false."
             echo "Only blocking execution if running previous jobs matching this job: ${JOB_NAME}"
-            oldest_running_build_num=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.workflows.created_at)|  .[0].build_num" /tmp/augmented_jobstatus.json`
-            oldest_commit_time=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.workflows.created_at)|  .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
+            oldest_running_build_num=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.committer_date)|  .[0].build_num" /tmp/augmented_jobstatus.json`
+            oldest_commit_time=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.committer_date)|  .[0].committer_date" /tmp/augmented_jobstatus.json`
           fi
           if [ -z "$oldest_commit_time" ]; then
             echo "API Error - unable to load previous job timings. Report to developer."
@@ -198,7 +198,7 @@ steps:
         }
 
         load_current_workflow_values(){
-           my_commit_time=`jq '.[] | select( .build_num == '"${CIRCLE_BUILD_NUM}"').workflows.created_at' /tmp/augmented_jobstatus.json`
+           my_commit_time=`jq '.[] | select( .build_num == '"${CIRCLE_BUILD_NUM}"').committer_date' /tmp/augmented_jobstatus.json`
         }
 
         cancel_current_build(){

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -177,13 +177,13 @@ steps:
             echo "Orb parameter block-workflow is true."
             if [ "<<parameters.only-on-workflow>>" = "*" ]; then
               echo "This job will block until no previous workflows have *any* jobs running."
-              oldest_running_build_num=`jq 'sort_by(.workflows.created_at)| .[0].build_num' /tmp/augmented_jobstatus.json`
-              oldest_commit_time=`jq 'sort_by(.workflows.created_at)| .[0].workflows.created_at' /tmp/augmented_jobstatus.json`
+              oldest_running_build_num=`jq 'sort_by(.committer_date)| .[0].build_num' /tmp/augmented_jobstatus.json`
+              oldest_commit_time=`jq 'sort_by(.committer_date)| .[0].committer_date' /tmp/augmented_jobstatus.json`
             else
               echo "Orb parameter only-on-workflow is true."
               echo "This job will block until no previous occurrences of workflow <<parameters.only-on-workflow>> have *any* jobs running."
-              oldest_running_build_num=`jq ". | map(select(.workflows.workflow_name| test(\"<<parameters.only-on-workflow>>\";\"sx\"))) | sort_by(.workflows.created_at)| .[0].build_num" /tmp/augmented_jobstatus.json`
-              oldest_commit_time=`jq ". | map(select(.workflows.workflow_name| test(\"<<parameters.only-on-workflow>>\";\"sx\"))) | sort_by(.workflows.created_at)| .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
+              oldest_running_build_num=`jq ". | map(select(.workflows.workflow_name| test(\"<<parameters.only-on-workflow>>\";\"sx\"))) | sort_by(.committer_date)| .[0].build_num" /tmp/augmented_jobstatus.json`
+              oldest_commit_time=`jq ". | map(select(.workflows.workflow_name| test(\"<<parameters.only-on-workflow>>\";\"sx\"))) | sort_by(.committer_date)| .[0].committer_date" /tmp/augmented_jobstatus.json`
             fi
           else
             echo "Orb parameter block-workflow is false."


### PR DESCRIPTION
### THIS IS A BREAKING CHANGE

Per issue #22 , BB did not pass commit specific timing, and so we used worklflow.  

### Motivation, issues

In a world of dynamic config many workflows can start after their initial pipeline, and will not follow in sequential order.  We therefore cant use workflow timing data.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
