### PR TITLE
Fix until_front_of_line null timestamps

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -177,19 +177,19 @@ steps:
             echo "Orb parameter block-workflow is true."
             if [ "<<parameters.only-on-workflow>>" = "*" ]; then
               echo "This job will block until no previous workflows have *any* jobs running."
-              oldest_running_build_num=`jq 'sort_by(.committer_date)| .[0].build_num' /tmp/augmented_jobstatus.json`
-              oldest_commit_time=`jq 'sort_by(.committer_date)| .[0].committer_date' /tmp/augmented_jobstatus.json`
+              oldest_running_build_num=`jq 'sort_by(.workflows.created_at)| .[0].build_num' /tmp/augmented_jobstatus.json`
+              oldest_commit_time=`jq 'sort_by(.workflows.created_at)| .[0].workflows.created_at' /tmp/augmented_jobstatus.json`
             else
               echo "Orb parameter only-on-workflow is true."
               echo "This job will block until no previous occurrences of workflow <<parameters.only-on-workflow>> have *any* jobs running."
-              oldest_running_build_num=`jq ". | map(select(.workflows.workflow_name| test(\"<<parameters.only-on-workflow>>\";\"sx\"))) | sort_by(.committer_date)| .[0].build_num" /tmp/augmented_jobstatus.json`
-              oldest_commit_time=`jq ". | map(select(.workflows.workflow_name| test(\"<<parameters.only-on-workflow>>\";\"sx\"))) | sort_by(.committer_date)| .[0].committer_date" /tmp/augmented_jobstatus.json`
+              oldest_running_build_num=`jq ". | map(select(.workflows.workflow_name| test(\"<<parameters.only-on-workflow>>\";\"sx\"))) | sort_by(.workflows.created_at)| .[0].build_num" /tmp/augmented_jobstatus.json`
+              oldest_commit_time=`jq ". | map(select(.workflows.workflow_name| test(\"<<parameters.only-on-workflow>>\";\"sx\"))) | sort_by(.workflows.created_at)| .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
             fi
           else
             echo "Orb parameter block-workflow is false."
             echo "Only blocking execution if running previous jobs matching this job: ${JOB_NAME}"
-            oldest_running_build_num=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.committer_date)|  .[0].build_num" /tmp/augmented_jobstatus.json`
-            oldest_commit_time=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.committer_date)|  .[0].committer_date" /tmp/augmented_jobstatus.json`
+            oldest_running_build_num=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.workflows.created_at)|  .[0].build_num" /tmp/augmented_jobstatus.json`
+            oldest_commit_time=`jq ". | map(select(.workflows.job_name | test(\"${JOB_NAME}\";\"sx\"))) | sort_by(.workflows.created_at)|  .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
           fi
           if [ -z "$oldest_commit_time" ]; then
             echo "API Error - unable to load previous job timings. Report to developer."
@@ -209,7 +209,7 @@ steps:
         }
 
         load_current_workflow_values(){
-           my_commit_time=`jq '.[] | select( .build_num == '"${CIRCLE_BUILD_NUM}"').committer_date' /tmp/augmented_jobstatus.json`
+           my_commit_time=`jq '.[] | select( .build_num == '"${CIRCLE_BUILD_NUM}"').workflows.created_at' /tmp/augmented_jobstatus.json`
         }
 
         cancel_current_build(){


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Fixes https://github.com/eddiewebb/circleci-queue/issues/104

I think this will fix the above issue. Please see my comment here: https://github.com/eddiewebb/circleci-queue/issues/104#issuecomment-1829733450

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Simply reverts the changes to `until_front_of_line.yml` in this latest merge commit to `main`: https://github.com/eddiewebb/circleci-queue/commit/e74ca30d0bc5a82b4d8fea49092f2551e62f698e
