### PR TITLE
Update README to clarify API token and permissions required [semver:patch]

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See https://github.com/eddiewebb/circleci-challenge as an example using blue/gre
 
 ## Basic Usage
 
-This adds concurrency limits by ensuring any jobs with this step will only continue once no previous builds are running. It supports a single argument of how many minutes to wait before aborting itself and it requires a single Environment Variable `CIRCLECI_API_KEY` - which can be created in [account settings](https://circleci.com/account/api).
+This adds concurrency limits by ensuring any jobs with this step will only continue once no previous builds are running. It supports a single argument of how many minutes to wait before aborting itself and it requires a single Environment Variable `CIRCLECI_API_KEY`, which must be a **Personal API Token** (rather than a project-specific API Permissions token). This can be created at [Personal API Tokens](https://app.circleci.com/settings/user/tokens) under Users Settings. Note that the account must have write access (at least the **Contributor** role) on the Project you wish to enable this orb for. However, if the `dont-quit` parameter is enabled, view-only access (the **Viewer** role) is sufficient.
 
 ## Screenshots / Examples
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -3,9 +3,11 @@ description: |
   Allows jobs or entire workflows to be queued to ensure they run in serial.  
   This is ideal for deployments or other activities that must not run concurrently.
   May optionaly consider branch-level isolation if unique branches should run concurrently. 
-  This orb requires the project to have an API key in order to query build states.
+  This orb requires the project to have an **Personal** API key in order to query build states.
   It requires a single environment variable CIRCLECI_API_KEY which can be created in account settings - https://circleci.com/account/api.
 
+
+  2.2.2: Docs clarity on token needs (@davidjb)
   2.2.1: fixes release version bug
   2.2.0: Adds 'filter-by-workflow' (@soniqua)
   2.0.0: Breaking change fixes dyanamic config, but may break Bitbucket users. 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Fixes #103 - clarifies which type of API token is required, updating the instructions (as the link and page have changed slightly) and the level of user access needed.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Update README to clarify the specific type of API token, update setup instructions, and clarify permissions required.

The CircleCI documentation is scant on information about what permissions are required to query and cancel jobs, but in testing in the UI at least, a user with Viewer access cannot cancel another user's running job, suggesting that Contributor (write access) is required for this orb to operate.
