### PR TITLE
Expose flag to fail job instead of canceling [semver:minor]

### DIFF
--- a/scripts/loop.bash
+++ b/scripts/loop.bash
@@ -255,9 +255,12 @@ while true; do
             fi
             exit 0
         else
-            cancel_build_num $CIRCLE_BUILD_NUM
-            sleep 5 # wait for API to cancel this job, rather than showing as failure
-            exit 1 # but just in case, fail job
+            if [ "$FAIL_INSTEAD_OF_CANCEL" != "true" ] ; then
+                cancel_build_num $CIRCLE_BUILD_NUM
+                sleep 5 # wait for API to cancel this job, rather than showing as failure
+                # but just in case, fail job
+            fi
+            exit 1
         fi
     fi
 

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -16,6 +16,10 @@ parameters:
     type: boolean
     default: false
     description: "Quitting is for losers. Force job through once time expires instead of failing."
+  fail-instead-of-cancel:
+    type: boolean
+    default: false
+    description: "Fail this command instead of canceling."
   force-cancel-previous:
     type: boolean
     default: false
@@ -62,18 +66,19 @@ steps:
       command: <<include(../scripts/loop.bash)>>
       shell: bash
       environment:  
-        ONLY_ON_BRANCH: <<parameters.limit-branch-name>>
         BLOCK_WORKFLOW: <<parameters.block-workflow>>
-        MAX_TIME: '<<parameters.max-wait-time>>'
-        DONT_QUIT: <<parameters.dont-quit>>
-        FORCE_CANCEL_PREVIOUS: <<parameters.force-cancel-previous>>
-        FILTER_BRANCH: << parameters.this-branch-only >>
-        ONLY_ON_WORKFLOW: <<parameters.limit-workflow-name>>
-        CONFIDENCE_THRESHOLD: <<parameters.confidence>>
         CCI_API_KEY_NAME: << parameters.circleci-api-key >>
-        TAG_PATTERN: <<parameters.tag-pattern>>
-        JOB_REGEXP: <<parameters.job-regex>>
         CIRCLECI_BASE_URL: https://<<parameters.circleci-hostname>>
-        MY_PIPELINE_NUMBER: <<parameters.my-pipeline>>
-        MY_BRANCH: "$CIRCLE_BRANCH"
+        CONFIDENCE_THRESHOLD: <<parameters.confidence>>
         DEBUG: <<parameters.include-debug>>
+        DONT_QUIT: <<parameters.dont-quit>>
+        FAIL_INSTEAD_OF_CANCEL: << parameters.fail-instead-of-cancel >>
+        FILTER_BRANCH: << parameters.this-branch-only >>
+        FORCE_CANCEL_PREVIOUS: <<parameters.force-cancel-previous>>
+        JOB_REGEXP: <<parameters.job-regex>>
+        MAX_TIME: '<<parameters.max-wait-time>>'
+        MY_BRANCH: "$CIRCLE_BRANCH"
+        MY_PIPELINE_NUMBER: <<parameters.my-pipeline>>
+        ONLY_ON_BRANCH: <<parameters.limit-branch-name>>
+        ONLY_ON_WORKFLOW: <<parameters.limit-workflow-name>>
+        TAG_PATTERN: <<parameters.tag-pattern>>

--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -16,6 +16,10 @@ parameters:
     type: boolean
     default: false
     description: "Quitting is for losers. Force job through once time expires instead of failing."
+  fail-instead-of-cancel:
+    type: boolean
+    default: false
+    description: "Fail this command instead of canceling."
   force-cancel-previous:
     type: boolean
     default: false
@@ -61,16 +65,17 @@ docker:
 resource_class: small
 steps:
   - until_front_of_line:
-      this-branch-only: <<parameters.this-branch-only>>
       block-workflow: <<parameters.block-workflow>>
-      max-wait-time: <<parameters.max-wait-time>>
-      dont-quit: <<parameters.dont-quit>>
-      limit-workflow-name: <<parameters.limit-workflow-name>>
-      limit-branch-name: <<parameters.limit-branch-name>>
-      confidence: <<parameters.confidence>>
       circleci-api-key: <<parameters.circleci-api-key>>
-      tag-pattern: <<parameters.tag-pattern>>
-      job-regex: <<parameters.job-regex>>
       circleci-hostname: <<parameters.circleci-hostname>>
-      my-pipeline: <<parameters.my-pipeline>>
+      confidence: <<parameters.confidence>>
+      dont-quit: <<parameters.dont-quit>>
+      fail-instead-of-cancel: << parameters.fail-instead-of-cancel >>
       include-debug: <<parameters.include-debug>>
+      job-regex: <<parameters.job-regex>>
+      limit-branch-name: <<parameters.limit-branch-name>>
+      limit-workflow-name: <<parameters.limit-workflow-name>>
+      max-wait-time: <<parameters.max-wait-time>>
+      my-pipeline: <<parameters.my-pipeline>>
+      tag-pattern: <<parameters.tag-pattern>>
+      this-branch-only: <<parameters.this-branch-only>>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Solves: https://github.com/eddiewebb/circleci-queue/issues/77

### Description

 With the use of a parameter in the command allow to fail the workflow instead of cancel.