### PR TITLE
Fix pr comment typo [semver:skip]  (#118)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ commands:
           command: |
             #During OPEN PR, get from CCI.
             PR_NUMBER=${CIRCLE_PULL_REQUEST##*/}
-            if [ -z "$PR)NUMBER" ];then
+            if [ -z "$PR_NUMBER" ];then
               # get from merge commit on closed PR.
               PR_NUMBER=`git log -1 --pretty=%s  | sed -En 's/.*\(#([0-9]*)\).*/\1/p'`
             fi


### PR DESCRIPTION
Should not publish the orb to prod but include dev pr info back in GH comments for this PR.

### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
