### PR TITLE
accept strings as pipeline IDs

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -54,7 +54,7 @@ parameters:
     default: "circleci.com"
     description: "For server user to specifiy custom hostname for their server"
   my-pipeline:
-    type: integer
+    type: string
   include-debug:
     type: boolean
     default: false

--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -54,7 +54,7 @@ parameters:
     default: "circleci.com"
     description: "For server user to specifiy custom hostname for their server"
   my-pipeline:
-    type: integer
+    type: string
   include-debug:
     type: boolean
     default: false


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

I'm attempting to use epoch time as the value for `my-pipeline`. Each close attempt I've made has failed on a similar error:

```
Type error for argument my-pipeline: expected type: integer, actual value: "$EPOCH_TIME" (type string)
```

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

I've checked `loop.bash` and there's nothing that assume my-pipeline is an integer, so this change shouldn't be an issue.

P.S. Thanks for creating a necessary feature that should have been packaged with CircleCI!! This will be the second time I use this in production. :)