### PR TITLE
fix(docs): consider-branch -> this-branch-only [semver:patch]

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,6 +6,7 @@ description: |
   This orb requires the project to have an **Personal** API key in order to query build states.
   It requires a single environment variable CIRCLECI_API_KEY which can be created in account settings - https://circleci.com/account/api.
 
+  3.2.1: Docs improvement, PR #136 Thanks @RainOfTerra
   3.2.0: Adds back-off support to handle 429 throttling from new API. PR #134  Thanks @rainofterra
   3.1.6: Fix #128 again, this time on JQ side. PR #133 Thanks @RainOfTerra
   3.1.5: Fix #128: allow spaces in job names and other bash bugs in PR #131, thanks @RainOfTerra

--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -31,7 +31,7 @@ parameters:
   limit-workflow-name:
     type: string
     default: "*"
-    description: "Only queue on a specified workflow. Consider combining this with `consider-branch`:`false`."
+    description: "Only queue on a specified workflow. Consider combining this with `this-branch-only`:`false`."
   # vcs-type --> pipeline.project.type
   confidence:
     type: string

--- a/src/jobs/block_workflow.yml
+++ b/src/jobs/block_workflow.yml
@@ -31,7 +31,7 @@ parameters:
   limit-workflow-name:
     type: string
     default: "*"
-    description: "Only queue on a specified workflow. Consider combining this with `consider-branch`:`false`."
+    description: "Only queue on a specified workflow. Consider combining this with `this-branch-only`:`false`."
   # vcs-type --> pipeline.project.type
   confidence:
     type: string


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

small doc fix

### Description

in #112 `consider-branch` was renamed to `this-branch-only` but I noticed the old name was in a couple spots in the docs.