### PR TITLE
Add timestamps to script output [semver:minor]

### DIFF
--- a/scripts/loop.bash
+++ b/scripts/loop.bash
@@ -4,6 +4,10 @@
 # This script uses many environment variables, some set from pipeline parameters. See orb yaml for source.
 #
 
+echo(){ # add UTC timestamps to echo
+    command echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC')" -- "$@"
+}
+
 load_variables(){
     TMP_DIR=$(mktemp -d)
     SHALLOW_JOBSTATUS_PATH="$TMP_DIR/jobstatus.json"

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,6 +6,7 @@ description: |
   This orb requires the project to have an **Personal** API key in order to query build states.
   It requires a single environment variable CIRCLECI_API_KEY which can be created in account settings - https://circleci.com/account/api.
 
+  3.3.0: Add timestamps to output, PR#139, thanks @jordan-brough
   3.2.1: Docs improvement, PR #136 Thanks @RainOfTerra
   3.2.0: Adds back-off support to handle 429 throttling from new API. PR #134  Thanks @rainofterra
   3.1.6: Fix #128 again, this time on JQ side. PR #133 Thanks @RainOfTerra


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

We've been debugging some queueing failures and having timestamps in the output would be helpful.

### Description

Adds timestamps to all usage of `echo` in the `loop.bash` script.
NOTE: I haven't tested this!