### PR TITLE
Fix conflict of 139 and 140 [semver:patch]

### DIFF
--- a/scripts/loop.bash
+++ b/scripts/loop.bash
@@ -14,7 +14,7 @@ load_variables(){
     AUGMENTED_JOBSTATUS_PATH="$TMP_DIR/augmented_jobstatus.json"
     echo "Block: $BLOCK_WORKFLOW"
     : "${MAX_TIME:?"Required Env Variable not found!"}"
-    wait_time=0
+    start_time=$(date +%s)
     loop_time=11
     max_time_seconds=$(( 60 * $MAX_TIME ))
     # just confirm our required variables are present
@@ -250,6 +250,15 @@ cancel_build_num(){
 }
 
 
+get_wait_time() {
+    local current_time
+    current_time=$(date +%s)
+    echo "$((current_time - start_time))"
+}
+
+
+
+
 
 
 
@@ -287,12 +296,14 @@ while true; do
     else
         # If we fail, reset confidence
         confidence=0
+        wait_time=$(get_wait_time)
         echo "This build (${CIRCLE_BUILD_NUM}), pipeline (${MY_PIPELINE_NUMBER}) is queued, waiting for build(${oldest_running_build_num}) pipeline (${front_of_queue_pipeline_number}) to complete."
         echo "Total Queue time: ${wait_time} seconds."
     fi
 
+    wait_time=$(get_wait_time)
     if [ $wait_time -ge $max_time_seconds ]; then
-        echo "Max wait time exceeded, fail or force cancel..."
+        echo "Max wait time exceeded. waited=$wait_time max=$max_time_seconds. Fail or force cancel..."
         if [ "${DONT_QUIT}" != "false" ]; then
             echo "Orb parameter dont-quit is set to true, letting this job proceed!"
             if [ "${FORCE_CANCEL_PREVIOUS}" != "false" ]; then
@@ -311,6 +322,5 @@ while true; do
     fi
 
     sleep $loop_time
-    wait_time=$(( loop_time + wait_time ))
 done
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,6 +6,7 @@ description: |
   This orb requires the project to have an **Personal** API key in order to query build states.
   It requires a single environment variable CIRCLECI_API_KEY which can be created in account settings - https://circleci.com/account/api.
 
+  3.3.1: Calculate wait time via wall clock, PR#140, thanks @jordan-brough
   3.3.0: Add timestamps to output, PR#139, thanks @jordan-brough
   3.2.1: Docs improvement, PR #136 Thanks @RainOfTerra
   3.2.0: Adds back-off support to handle 429 throttling from new API. PR #134  Thanks @rainofterra

--- a/test/test_expansion.bats
+++ b/test/test_expansion.bats
@@ -35,7 +35,7 @@ function setup {
   load_config_parameters
   export CIRCLE_REPOSITORY_URL="git@bitbucket.org:deedee/deeedee.git"
   run bash scripts/loop.bash
-  echo $ouput
+  echo $output
 
   assert_contains_text "VCS_TYPE set to bitbucket"
 }
@@ -49,7 +49,7 @@ function setup {
   load_config_parameters 
   export CIRCLE_REPOSITORY_URL="git@bebop.org:deedee/deeedee.git"
   run bash scripts/loop.bash
-  echo $ouput
+  echo $output
 
   assert_text_not_found "VCS_TYPE set to bitbucket"
 }
@@ -68,7 +68,7 @@ function setup {
   export CIRCLE_BRANCH="main"
   load_config_parameters "Single File"
   run bash scripts/loop.bash
-  echo $ouput
+  echo $output
 
 
   assert_contains_text "Orb parameter block-workflow is true."
@@ -88,7 +88,7 @@ function setup {
   export CIRCLE_BRANCH="main"
   load_config_parameters "Single File"
   run bash scripts/loop.bash
-  echo $ouput
+  echo $output
 
 
   assert_contains_text "Orb parameter block-workflow is false"
@@ -107,7 +107,7 @@ function setup {
   export TESTING_MOCK_WORKFLOW_RESPONSES=test/api/workflows
   export CIRCLE_JOB=DeployStep1
   run bash scripts/loop.bash
-  echo $ouput
+  echo $output
 
   assert_contains_text "Max Queue Time: 6 seconds"
   assert_contains_text "Max wait time exceeded"
@@ -127,7 +127,7 @@ function setup {
   load_config_parameters
   export CIRCLE_JOB="DeployStep1"
   run bash scripts/loop.bash
-  echo $ouput
+  echo $output
 
 
   assert_contains_text "Max Queue Time: 6 seconds"
@@ -147,7 +147,7 @@ function setup {
   
   load_config_parameters
   run bash scripts/loop.bash
-  echo $ouput
+  echo $output
 
 
   assert_contains_text "Max Queue Time: 6 seconds"
@@ -167,7 +167,7 @@ function setup {
   export CIRCLE_BRANCH="main"
   load_config_parameters
   run bash scripts/loop.bash
-  echo $ouput
+  echo $output
 
 
   assert_contains_text "Max Queue Time: 6 seconds"
@@ -185,7 +185,7 @@ function setup {
   export CIRCLE_BRANCH="main"
   load_config_parameters
   run bash scripts/loop.bash
-  echo $ouput
+  echo $output
 
 
   assert_contains_text "Max Queue Time: 6 seconds"
@@ -205,7 +205,7 @@ function setup {
   export CIRCLE_BRANCH="main"
   load_config_parameters
   run bash scripts/loop.bash
-  echo $ouput
+  echo $output
 
 
   assert_contains_text "Max Queue Time: 6 seconds"
@@ -225,7 +225,7 @@ function setup {
   export CIRCLE_BRANCH="main"
   load_config_parameters
   run bash scripts/loop.bash
-  echo $ouput
+  echo $output
 
   assert_contains_text "Max Queue Time: 6 seconds"
   assert_contains_text "Orb parameter 'this-branch-only' is false, will block previous builds on any branch"
@@ -249,7 +249,7 @@ function setup {
   export CIRCLE_BRANCH="main"
   load_config_parameters
   run bash scripts/loop.bash
-  echo $ouput
+  echo $output
 
 
   assert_contains_text "${CIRCLE_BRANCH} matches queueable branch names"
@@ -277,7 +277,7 @@ function setup {
   export CIRCLE_PR_REPONAME="this/was/forked"
   export TRIGGER_SOURCE="1" 
   run bash scripts/loop.bash
-  echo $ouput
+  echo $output
 
 
   assert_contains_text "Queueing on forks is not supported. Skipping queue..."


### PR DESCRIPTION
While #139 and #140 were both valid in their own right, the use of `echo` override in the former broke calculation in the latter. 

This change replaces `echo` with `log` to keep timestamps and allow functions to return values.