### PR TITLE
docs: add deprecation note to README [semver:skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **This Orb is deprecated by native CircleCI functionality.**
+>
+> For details, see the [Deprecation Notice issue](https://github.com/eddiewebb/circleci-queue/issues/142) and the official [CircleCI changelog entry](https://circleci.com/changelog/avoid-commit-conflicts-in-your-pipelines-with-serial-jobs/) for `serial-group`.
+
 # CircleCI Concurrency Control Orb
 
 [![CircleCI](https://img.shields.io/circleci/build/gh/eddiewebb/circleci-queue)](https://circleci.com/gh/eddiewebb/circleci-queue/tree/master) 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
So folks reading the main project page in GitHub are aware of the status of the project and repository. The GitHub issue helps, but is tucked away. 

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
This adds a deprecation notice to the top of the README so it’s clear as to the status of this project. It links to the underlying GitHub Issue with the notice so this can easily be seen, and links to the offical CircleCI release notes and description of the new feature as well.